### PR TITLE
Compatibility to PHPCS 3.3.0 and Bugfixes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,10 +6,12 @@
     <testsuites>
         <testsuite name="AllUnitTests">
             <directory>./tests/Unit/</directory>
+            <exclude>./tests/Functional/Plugin/Fixtures/ComposerTest/vendor*</exclude>
         </testsuite>
 
         <testsuite name="AllFunctionalTests">
             <directory>./tests/Functional/</directory>
+            <exclude>./tests/Functional/Plugin/Fixtures/ComposerTest/vendor*</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/config/phpcs/ZooroyalDefault/ruleset.xml
+++ b/src/config/phpcs/ZooroyalDefault/ruleset.xml
@@ -69,7 +69,14 @@
     <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions"
+                      type="array"
+                      value="sizeof=>count,delete=>unset,print=>echo,is_null=>null,create_function=>null,ob_end_flush=>null,chop=>rtrim,close=>closedir,die=>exit,diskfreespace=>disk_free_space,doubleval=>floatval,fputs=>fwrite,gzputs=>gzwrite,i18n_convert=>mb_convert_encoding,i18n_discover_encoding=>mb_detect_encoding,i18n_http_input=>mb_http_input,i18n_http_output=>mb_http_output,i18n_internal_encoding=>mb_internal_encoding,i18n_ja_jp_hantozen=>mb_convert_kana,i18n_mime_header_decode=>mb_decode_mimeheader,i18n_mime_header_encode=>mb_encode_mimeheader,imap_create=>imap_createmailbox,imap_fetchtext=>imap_body,imap_getmailboxes=>imap_list_full,imap_getsubscribed=>imap_lsub_full,imap_header=>imap_headerinfo,imap_listmailbox=>imap_list,imap_listsubscribed=>imap_lsub,imap_rename=>imap_renamemailbox,imap_scan=>imap_listscan,imap_scanmailbox=>imap_listscan,ini_alter=>ini_set,is_double=>is_float,is_integer=>is_int,is_long=>is_int,is_real=>is_float,is_writeable=>is_writable,join=>implode,key_exists=>array_key_exists,ldap_close=>ldap_unbind,magic_quotes_runtime=>set_magic_quotes_runtime,mbstrcut=>mb_strcut,mbstrlen=>mb_strlen,mbstrpos=>mb_strpos,mbstrrpos=>mb_strrpos,mbsubstr=>mb_substr,mysql=>mysql_db_query,mysql_createdb=>mysql_create_db,mysql_db_name=>mysql_result,mysql_dbname=>mysql_result,mysql_dropdb=>mysql_drop_db,mysql_fieldflags=>mysql_field_flags,mysql_fieldlen=>mysql_field_len,mysql_fieldname=>mysql_field_name,mysql_fieldtable=>mysql_field_table,mysql_fieldtype=>mysql_field_type,mysql_freeresult=>mysql_free_result,mysql_listdbs=>mysql_list_dbs,mysql_listfields=>mysql_list_fields,mysql_listtables=>mysql_list_tables,mysql_numfields=>mysql_num_fields,mysql_numrows=>mysql_num_rows,mysql_selectdb=>mysql_select_db,mysql_tablename=>mysql_result,odbc_do=>odbc_exec,odbc_field_precision=>odbc_field_len,pdf_add_outline=>pdf_add_bookmark,pg_clientencoding=>pg_client_encoding,pg_setclientencoding=>pg_set_client_encoding,pos=>current,recode=>recode_string,show_source=>highlight_file,sizeof=>count,snmpwalkoid=>snmprealwalk,strchr=>strstr,xptr_new_context=>xpath_new_context"
+            />
+        </properties>
+    </rule>
     <rule ref="Generic.PHP.LowerCaseConstant"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
@@ -118,12 +125,10 @@
             <property name="maxPercentage" value="49"/>
         </properties>
     </rule>
-    <rule ref="Squiz.PHP.DisallowObEndFlush"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
     <rule ref="Squiz.PHP.DiscouragedFunctions"/>
     <rule ref="Squiz.PHP.EmbeddedPhp"/>
     <rule ref="Squiz.PHP.Eval"/>
-    <rule ref="Squiz.PHP.ForbiddenFunctions"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.Heredoc"/>
     <rule ref="Squiz.PHP.InnerFunctions"/>

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -38,7 +38,7 @@ class Environment
     public function getLocalBranch()
     {
         if ($this->localBranch === null) {
-            $this->localBranch = $this->processRunner->runAsProcess('git name-rev --name-only HEAD');
+            $this->localBranch = $this->processRunner->runAsProcess('git name-rev --exclude=tag\* --name-only HEAD');
         }
 
         return $this->localBranch;

--- a/src/main/php/CommandLine/Library/GenericCommandRunner.php
+++ b/src/main/php/CommandLine/Library/GenericCommandRunner.php
@@ -84,14 +84,24 @@ class GenericCommandRunner
      * @param string $stopword
      * @param string $prefix
      * @param string $glue
+     * @param bool   $escape if true the blacklist entries will be escaped for regexp
      *
      * @return int|null
      */
-    public function runBlacklistCommand($template, $stopword, $prefix = '', $glue = ',')
+    public function runBlacklistCommand($template, $stopword, $prefix = '', $glue = ',', $escape = false)
     {
         $blackList = $this->blacklistFactory->build($stopword);
-        $argument  = $prefix . implode($glue . $prefix, $blackList);
-        $command   = $this->buildCommand($template, $argument);
+        if ($escape) {
+            $blackList = array_map(
+                function ($value) {
+                    return preg_quote(preg_quote($value, '/'), '/');
+                },
+                $blackList
+            );
+        }
+        $argument = $prefix . implode($glue . $prefix, $blackList);
+
+        $command = $this->buildCommand($template, $argument);
 
         return $this->runAndWriteToOutput($command);
     }

--- a/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
@@ -115,7 +115,10 @@ class PHPCodeSnifferAdapter implements FixerSupportInterface
             $command  = $this->commands[$tool . 'BL'];
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $command,
-                $this->stopword
+                $this->stopword,
+                '',
+                ',',
+                true
             );
         } else {
             $this->output->writeln($diffMessage . ' diff to ' . $targetBranch, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/Library/EnvironmentTest.php
+++ b/tests/Unit/CommandLine/Library/EnvironmentTest.php
@@ -63,7 +63,7 @@ class EnvironmentTest extends TestCase
     public function getLocalBranch()
     {
         $this->mockedProcessRunner->shouldReceive('runAsProcess')->once()
-            ->with('git name-rev --name-only HEAD')->andReturn($this->localBranch);
+            ->with('git name-rev --exclude=tag\* --name-only HEAD')->andReturn($this->localBranch);
 
         $this->subject->getLocalBranch();
         $result = $this->subject->getLocalBranch();

--- a/tests/Unit/CommandLine/Library/GenericCommandRunnerTest.php
+++ b/tests/Unit/CommandLine/Library/GenericCommandRunnerTest.php
@@ -181,6 +181,48 @@ class GenericCommandRunnerTest extends TestCase
         self::assertSame($mockedExitCode, $result);
     }
 
+
+    /**
+     * @test
+     */
+    public function runBlacklistCommandEscaped()
+    {
+        $mockedTemplate         = 'My Template %1$s';
+        $mockedStopword         = 'HALT';
+        $mockedPrefix           = 'teil mich!';
+        $mockedGlue             = 'juhu';
+        $mockedBlacklist        = ['mocked', '.files'];
+        $mockedEscapedBlacklist = ['mocked', '\\\\\.files'];
+        $mockedOutput           = 'Das hab ich zu sagen.';
+        $mockedErrorOutput      = 'ERRRRRRRRRRRRROROROROROR';
+        $mockedExitCode         = 0;
+
+        $this->prepareMocksForRunAndWriteToOutput(
+            $mockedEscapedBlacklist,
+            $mockedTemplate,
+            $mockedOutput,
+            $mockedErrorOutput,
+            $mockedGlue,
+            $mockedPrefix
+        );
+        $this->subjectParameters[BlacklistFactory::class]->shouldReceive('build')->once()
+            ->with($mockedStopword)->andReturn($mockedBlacklist);
+
+        $this->mockedProcess->shouldReceive('getExitCode')->withNoArgs()->andReturn($mockedExitCode);
+        $this->subjectParameters[OutputInterface::class]->shouldReceive('writeln')->times($mockedExitCode)
+            ->with($mockedOutput, OutputInterface::OUTPUT_NORMAL);
+
+        $result = $this->subject->runBlacklistCommand(
+            $mockedTemplate,
+            $mockedStopword,
+            $mockedPrefix,
+            $mockedGlue,
+            true
+        );
+
+        self::assertSame($mockedExitCode, $result);
+    }
+
     /**
      * Prepares mocks for calls of private buildCommand with no ProcessIsolation
      *

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -129,7 +129,15 @@ class PHPCodeSnifferAdapterTest extends TestCase
 
     /**
      * @test
-     * @dataProvider                                writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
+     * @param string $method
+     * @param string $message
+     * @param string $command
+     * @param string $mockedLocalBranch
+     * @param string $mockedTargetBranch
+     *
+     * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(
@@ -154,7 +162,7 @@ class PHPCodeSnifferAdapterTest extends TestCase
             ->with($message, OutputInterface::VERBOSITY_NORMAL);
 
         $this->mockedGenericCommandRunner->shouldReceive('runBlacklistCommand')->once()
-            ->with($$command, $this->expectedStopword)
+            ->with($$command, $this->expectedStopword, '', ',', true)
             ->andReturn($this->expectedExitCode);
 
         $result = $this->subject->$method($mockedTargetBranch, $this->mockedProcessisolation);


### PR DESCRIPTION
* Compatibility to PHPCS. Moved to Generic.PHP.ForbiddenFunctions
* Ignore parameter for PHPCS did not work with . in path
* Coding-standard will not use tags to identify local branch anymore