### PR TITLE
DEV-2095 alias bug

### DIFF
--- a/src/main/php/CommandLine/Commands/FindFilesToCheckCommand.php
+++ b/src/main/php/CommandLine/Commands/FindFilesToCheckCommand.php
@@ -66,7 +66,7 @@ class FindFilesToCheckCommand extends Command
 
         if ($exclusive === true) {
             $result = $this->blacklistFactory->build($stopword);
-        } elseif (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        } elseif (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $result = $this->allCheckableFileFinder->findFiles($filter, $stopword);
         } else {
             $result = $this->diffCheckableFileFinder->findFiles($filter, $stopword, $targetBranch);

--- a/src/main/php/CommandLine/Commands/FindFilesToCheckCommand.php
+++ b/src/main/php/CommandLine/Commands/FindFilesToCheckCommand.php
@@ -66,7 +66,7 @@ class FindFilesToCheckCommand extends Command
 
         if ($exclusive === true) {
             $result = $this->blacklistFactory->build($stopword);
-        } elseif (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        } elseif (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $result = $this->allCheckableFileFinder->findFiles($filter, $stopword);
         } else {
             $result = $this->diffCheckableFileFinder->findFiles($filter, $stopword, $targetBranch);

--- a/src/main/php/CommandLine/FileFinders/DiffCheckableFileFinder.php
+++ b/src/main/php/CommandLine/FileFinders/DiffCheckableFileFinder.php
@@ -57,8 +57,7 @@ class DiffCheckableFileFinder implements FileFinderInterface
      */
     private function findRawDiff($targetBranch = '')
     {
-        $localBranch = $this->environment->getLocalBranch();
-        if ($localBranch === $targetBranch) {
+        if ($this->environment->isLocalBranchEqualTo($targetBranch)) {
             $rawDiffAsString = $this->findFilesOfBranch();
         } else {
             $rawDiffAsString = $this->findFilesInDiffToTarget($targetBranch);

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -42,8 +42,7 @@ class Environment
     {
         return realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
             . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
-            . DIRECTORY_SEPARATOR . ''
-        );
+            . DIRECTORY_SEPARATOR . '');
     }
 
     public function getBlacklistedDirectories()

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -1,12 +1,15 @@
 <?php
 namespace Zooroyal\CodingStandard\CommandLine\Library;
 
+/**
+ * This Class supplies information about the environment the script is running in.
+ */
 class Environment
 {
     /** @var string */
     private $rootDirectory;
     /** @var string */
-    private $localBranch;
+    private $localHeadHash;
 
     /** @var string[] */
     private $blacklistedDirectories = [
@@ -35,24 +38,45 @@ class Environment
         return $this->rootDirectory;
     }
 
-    public function getLocalBranch()
-    {
-        if ($this->localBranch === null) {
-            $this->localBranch = $this->processRunner->runAsProcess('git name-rev --exclude=tag\* --name-only HEAD');
-        }
-
-        return $this->localBranch;
-    }
-
     public function getPackageDirectory()
     {
         return realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
             . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
-            . DIRECTORY_SEPARATOR . '');
+            . DIRECTORY_SEPARATOR . ''
+        );
     }
 
     public function getBlacklistedDirectories()
     {
         return $this->blacklistedDirectories;
+    }
+
+    /**
+     * Compare if the HEAD of $targetBrnach equals the HEAD of the local branch.
+     *
+     * @param string $targetBranch
+     *
+     * @return bool
+     */
+    public function isLocalBranchEqualTo($targetBranch)
+    {
+        if ($this->localHeadHash === null) {
+            $this->localHeadHash = $this->commitishToHash('HEAD');
+        }
+        $targetCommitHash = $this->commitishToHash($targetBranch);
+
+        return $targetCommitHash === $this->localHeadHash;
+    }
+
+    /**
+     * Converts a commit-tish to a commit hash.
+     *
+     * @param string $branchName
+     *
+     * @return string
+     */
+    private function commitishToHash($branchName)
+    {
+        return $this->processRunner->runAsProcess('git rev-list -n 1 ' . $branchName);
     }
 }

--- a/src/main/php/CommandLine/ToolAdapters/JSESLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/JSESLintAdapter.php
@@ -110,7 +110,7 @@ class JSESLintAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $template = $this->commands[$tool . 'BL'];
             $prefix   = '--ignore-pattern=';

--- a/src/main/php/CommandLine/ToolAdapters/JSESLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/JSESLintAdapter.php
@@ -110,7 +110,7 @@ class JSESLintAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $template = $this->commands[$tool . 'BL'];
             $prefix   = '--ignore-pattern=';

--- a/src/main/php/CommandLine/ToolAdapters/JSStyleLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/JSStyleLintAdapter.php
@@ -112,7 +112,7 @@ class JSStyleLintAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->commands[$tool . 'BL'],

--- a/src/main/php/CommandLine/ToolAdapters/JSStyleLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/JSStyleLintAdapter.php
@@ -112,7 +112,7 @@ class JSStyleLintAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->commands[$tool . 'BL'],

--- a/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
@@ -110,7 +110,7 @@ class PHPCodeSnifferAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $command  = $this->commands[$tool . 'BL'];
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(

--- a/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
@@ -110,7 +110,7 @@ class PHPCodeSnifferAdapter implements FixerSupportInterface
      */
     private function runTool($targetBranch, $processIsolation, $fullMessage, $tool, $diffMessage)
     {
-        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $this->output->writeln($fullMessage, OutputInterface::VERBOSITY_NORMAL);
             $command  = $this->commands[$tool . 'BL'];
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(

--- a/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
@@ -60,7 +60,7 @@ class PHPMessDetectorAdapter implements ToolAdapterInterface
      */
     public function writeViolationsToOutput($targetBranch = '', $processIsolation = false)
     {
-        if (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $this->output->writeln('Running full check.', OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->messDetectCommandBlacklist,

--- a/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
@@ -60,7 +60,7 @@ class PHPMessDetectorAdapter implements ToolAdapterInterface
      */
     public function writeViolationsToOutput($targetBranch = '', $processIsolation = false)
     {
-        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $this->output->writeln('Running full check.', OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->messDetectCommandBlacklist,

--- a/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
@@ -59,7 +59,7 @@ class PHPParallelLintAdapter implements ToolAdapterInterface
      */
     public function writeViolationsToOutput($targetBranch = '', $processIsolation = false)
     {
-        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('origin/master')) {
             $this->output->writeln('Running full check.', OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->parallelLintBlacklistCommand,

--- a/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
@@ -59,7 +59,7 @@ class PHPParallelLintAdapter implements ToolAdapterInterface
      */
     public function writeViolationsToOutput($targetBranch = '', $processIsolation = false)
     {
-        if (empty($targetBranch) || $this->environment->getLocalBranch() === 'master') {
+        if (empty($targetBranch) || $this->environment->isLocalBranchEqualTo('master')) {
             $this->output->writeln('Running full check.', OutputInterface::VERBOSITY_NORMAL);
             $exitCode = $this->genericCommandRunner->runBlacklistCommand(
                 $this->parallelLintBlacklistCommand,

--- a/tests/Unit/CommandLine/Commands/FindFilesToCheckCommandTest.php
+++ b/tests/Unit/CommandLine/Commands/FindFilesToCheckCommandTest.php
@@ -172,8 +172,8 @@ class FindFilesToCheckCommandTest extends TestCase
         $mockedInputInterface->shouldReceive('getOption')->once()
             ->with('exclusionList')->andReturn($mockedExclusiveFlag);
 
-        $this->subjectParameters[Environment::class]->shouldReceive('getLocalBranch')->once()
-            ->withNoArgs()->andReturn('blaaa');
+        $this->subjectParameters[Environment::class]->shouldReceive('isLocalBranchEqualTo')->once()
+            ->with('master')->andReturn(false);
 
         $this->subjectParameters[DiffCheckableFileFinder::class]->shouldReceive('findFiles')->once()
             ->with($mockedFilter, $mockedStopword, $mockedTargetBranch)->andReturn($expectedArray);

--- a/tests/Unit/CommandLine/Commands/FindFilesToCheckCommandTest.php
+++ b/tests/Unit/CommandLine/Commands/FindFilesToCheckCommandTest.php
@@ -173,7 +173,7 @@ class FindFilesToCheckCommandTest extends TestCase
             ->with('exclusionList')->andReturn($mockedExclusiveFlag);
 
         $this->subjectParameters[Environment::class]->shouldReceive('isLocalBranchEqualTo')->once()
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->subjectParameters[DiffCheckableFileFinder::class]->shouldReceive('findFiles')->once()
             ->with($mockedFilter, $mockedStopword, $mockedTargetBranch)->andReturn($expectedArray);

--- a/tests/Unit/CommandLine/FileFinders/DiffCheckableFileFinderTest.php
+++ b/tests/Unit/CommandLine/FileFinders/DiffCheckableFileFinderTest.php
@@ -45,13 +45,12 @@ class DiffCheckableFileFinderTest extends TestCase
         $mockedTargetBranch = 'blaBranch';
         $mockedFilter       = 'blaFilter';
         $mockedStopWord     = 'blaStopword';
-        $mockedLocalBranch  = 'blaLocalBranch';
         $mockedMergeBase    = 'alsdkfujh178290346';
         $mockedFileDiff     = 'dir1/file1' . "\n" . 'dir2/file2' . "\n";
         $mockedFiles        = ['dir1/file1', 'dir2/file2'];
 
-        $this->subjectParameters[Environment::class]->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn($mockedLocalBranch);
+        $this->subjectParameters[Environment::class]->shouldReceive('isLocalBranchEqualTo')->once()
+            ->with($mockedTargetBranch)->andReturn(false);
         $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')
             ->with('git merge-base HEAD ' . $mockedTargetBranch)
             ->andReturn($mockedMergeBase);
@@ -78,8 +77,8 @@ class DiffCheckableFileFinderTest extends TestCase
         $mockedFileDiff     = 'dir1/file1' . "\n" . 'dir2/file2' . "\n";
         $mockedFiles        = ['dir1/file1', 'dir2/file2'];
 
-        $this->subjectParameters[Environment::class]->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn($mockedLocalBranch);
+        $this->subjectParameters[Environment::class]->shouldReceive('isLocalBranchEqualTo')->once()
+            ->with($mockedLocalBranch)->andReturn(true);
         $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')
             ->with(H::startsWith('git cat-file -t HEAD'))
             ->andReturn('commit', 'commit', 'tag');

--- a/tests/Unit/CommandLine/ToolAdapters/JSESLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/JSESLintAdapterTest.php
@@ -87,7 +87,7 @@ class JSESLintAdapterTest extends TestCase
             . '--config=' . $this->mockedPackageDirectory . '/src/config/eslint/.eslintrc.js %1$s';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')->once()
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -156,7 +156,7 @@ class JSESLintAdapterTest extends TestCase
             . $this->mockedRootDirectory;
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn($equalToLocalBranch);
+            ->with('origin/master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/JSESLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/JSESLintAdapterTest.php
@@ -81,14 +81,13 @@ class JSESLintAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForWhitelistCheck()
     {
-        $mockedLocalBranch  = 'myLocalBranch';
         $mockedTargetBranch = 'myTarget';
 
         $expectedCommand = $this->mockedPackageDirectory . '/node_modules/eslint/bin/eslint.js '
             . '--config=' . $this->mockedPackageDirectory . '/src/config/eslint/.eslintrc.js %1$s';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')->once()
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -117,28 +116,36 @@ class JSESLintAdapterTest extends TestCase
                 'writeViolationsToOutput',
                 'Running full check.',
                 'expectedWrite',
-                'master',
                 'myTarget',
+                true
             ],
-            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'myBranch', ''],
-            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'master', ''],
-            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', 'myTarget'],
-            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myBranch', ''],
-            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', ''],
+            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite',  '', false],
+            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', '', true],
+            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myTarget', true],
+            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', '', false],
+            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', '', true],
         ];
     }
 
     /**
      * @test
-     * @dataProvider                                writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
+     * @param string $method
+     * @param string $message
+     * @param string $command
+     * @param string $mockedTargetBranch
+     * @param string $equalToLocalBranch
+     *
+     * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(
         $method,
         $message,
         $command,
-        $mockedLocalBranch,
-        $mockedTargetBranch
+        $mockedTargetBranch,
+        $equalToLocalBranch
     ) {
         $expectedWrite = $this->mockedPackageDirectory . '/node_modules/eslint/bin/eslint.js '
             . '--config=' . $this->mockedPackageDirectory . '/src/config/eslint/.eslintrc.js %1$s '
@@ -148,8 +155,8 @@ class JSESLintAdapterTest extends TestCase
             . '--config=' . $this->mockedPackageDirectory . '/src/config/eslint/.eslintrc.js --fix %1$s '
             . $this->mockedRootDirectory;
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
@@ -116,9 +116,9 @@ class JSStyleLintAdapterTest extends TestCase
                 'Running full check.',
                 'expectedWrite',
                 'myTarget',
-                true
+                true,
             ],
-            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite',  '', false],
+            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', '', false],
             'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', '', true],
             'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myTarget', true],
             'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', '', false],
@@ -136,6 +136,7 @@ class JSStyleLintAdapterTest extends TestCase
      * @param string $equalToLocalBranch
      *
      * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(

--- a/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
@@ -86,7 +86,7 @@ class JSStyleLintAdapterTest extends TestCase
             . $this->mockedPackageDirectory . '/src/config/stylelint/.stylelintrc %1$s';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')->once()
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -154,7 +154,7 @@ class JSStyleLintAdapterTest extends TestCase
             . $this->mockedRootDirectory . '/**' . $this->expectedFilter;
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn($equalToLocalBranch);
+            ->with('origin/master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/JSStyleLintAdapterTest.php
@@ -81,13 +81,12 @@ class JSStyleLintAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForWhitelistCheck()
     {
-        $mockedLocalBranch  = 'myLocalBranch';
         $mockedTargetBranch = 'myTarget';
         $expectedCommand    = $this->mockedPackageDirectory . '/node_modules/stylelint/bin/stylelint.js --config='
             . $this->mockedPackageDirectory . '/src/config/stylelint/.stylelintrc %1$s';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')->once()
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -116,28 +115,35 @@ class JSStyleLintAdapterTest extends TestCase
                 'writeViolationsToOutput',
                 'Running full check.',
                 'expectedWrite',
-                'master',
                 'myTarget',
+                true
             ],
-            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'myBranch', ''],
-            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'master', ''],
-            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', 'myTarget'],
-            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myBranch', ''],
-            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', ''],
+            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite',  '', false],
+            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', '', true],
+            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myTarget', true],
+            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', '', false],
+            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', '', true],
         ];
     }
 
     /**
      * @test
-     * @dataProvider                                writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
+     * @param string $method
+     * @param string $message
+     * @param string $command
+     * @param string $mockedTargetBranch
+     * @param string $equalToLocalBranch
+     *
+     * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(
         $method,
         $message,
         $command,
-        $mockedLocalBranch,
-        $mockedTargetBranch
+        $mockedTargetBranch,
+        $equalToLocalBranch
     ) {
         $expectedWrite = $this->mockedPackageDirectory . '/node_modules/stylelint/bin/stylelint.js '
             . '--config=' . $this->mockedPackageDirectory . '/src/config/stylelint/.stylelintrc %1$s '
@@ -147,8 +153,8 @@ class JSStyleLintAdapterTest extends TestCase
             . '--config=' . $this->mockedPackageDirectory . '/src/config/stylelint/.stylelintrc --fix %1$s '
             . $this->mockedRootDirectory . '/**' . $this->expectedFilter;
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -86,8 +86,8 @@ class PHPCodeSnifferAdapterTest extends TestCase
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
             . $this->mockedPackageDirectory . '/src/config/phpcs/ZooroyalDefault/ruleset.xml %1$s';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -116,14 +116,14 @@ class PHPCodeSnifferAdapterTest extends TestCase
                 'writeViolationsToOutput',
                 'Running full check.',
                 'expectedWrite',
-                'master',
                 'myTarget',
+                true
             ],
-            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'myBranch', ''],
-            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', 'master', ''],
-            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', 'myTarget'],
-            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myBranch', ''],
-            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', 'master', ''],
+            'empty target'     => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite',  '', false],
+            'both'             => ['writeViolationsToOutput', 'Running full check.', 'expectedWrite', '', true],
+            'fix local master' => ['fixViolations', 'Fix all Files.', 'expectedFix', 'myTarget', true],
+            'fix empty target' => ['fixViolations', 'Fix all Files.', 'expectedFix', '', false],
+            'fix both'         => ['fixViolations', 'Fix all Files.', 'expectedFix', '', true],
         ];
     }
 
@@ -133,19 +133,18 @@ class PHPCodeSnifferAdapterTest extends TestCase
      * @param string $method
      * @param string $message
      * @param string $command
-     * @param string $mockedLocalBranch
      * @param string $mockedTargetBranch
+     * @param string $equalToLocalBranch
      *
      * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
-     *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(
         $method,
         $message,
         $command,
-        $mockedLocalBranch,
-        $mockedTargetBranch
+        $mockedTargetBranch,
+        $equalToLocalBranch
     ) {
         $expectedWrite = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
             . $this->mockedPackageDirectory . '/src/config/phpcs/ZooroyalDefault/ruleset.xml --ignore=%1$s '
@@ -155,8 +154,8 @@ class PHPCodeSnifferAdapterTest extends TestCase
             . $this->mockedPackageDirectory . '/src/config/phpcs/ZooroyalDefault/ruleset.xml --ignore=%1$s '
             . $this->mockedRootDirectory;
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -87,7 +87,7 @@ class PHPCodeSnifferAdapterTest extends TestCase
             . $this->mockedPackageDirectory . '/src/config/phpcs/ZooroyalDefault/ruleset.xml %1$s';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -155,7 +155,7 @@ class PHPCodeSnifferAdapterTest extends TestCase
             . $this->mockedRootDirectory;
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn($equalToLocalBranch);
+            ->with('origin/master')->andReturn($equalToLocalBranch);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with($message, OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -81,7 +81,6 @@ class PHPCodeSnifferAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForWhitelistCheck()
     {
-        $mockedLocalBranch  = 'myLocalBranch';
         $mockedTargetBranch = 'myTarget';
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
             . $this->mockedPackageDirectory . '/src/config/phpcs/ZooroyalDefault/ruleset.xml %1$s';
@@ -137,6 +136,7 @@ class PHPCodeSnifferAdapterTest extends TestCase
      * @param string $equalToLocalBranch
      *
      * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck(

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
@@ -90,7 +90,7 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
             '--names-exclude=ZRBannerSlider.php,Installer.php,ZRPreventShipping.php %1$s ' . $this->mockedRootDirectory;
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
@@ -85,13 +85,12 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForBlacklistCheck()
     {
-        $mockedLocalBranch  = 'localBranch';
         $mockedTargetBranch = 'targetBranch';
         $expectedCommand    ='php ' . $this->mockedRootDirectory . '/vendor/bin/phpcpd -vvv --progress --fuzzy -n ' .
             '--names-exclude=ZRBannerSlider.php,Installer.php,ZRPreventShipping.php %1$s ' . $this->mockedRootDirectory;
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
@@ -84,8 +84,8 @@ class PHPMessDetectorAdapterTest extends TestCase
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpmd %1$s text '
             . $this->mockedPackageDirectory . '/src/config/phpmd/ZooRoyalDefault/phpmd.xml --suffixes php';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -102,24 +102,27 @@ class PHPMessDetectorAdapterTest extends TestCase
     public function writeViolationsToOutputWithTargetForBlacklistCheckDataProvider()
     {
         return [
-            'local master' => ['master', 'myTarget'],
-            'empty target' => ['myBranch', ''],
-            'both'         => ['master', ''],
+            'local master' => ['myTarget', true],
+            'empty target' => ['', false],
+            'both'         => ['', true],
         ];
     }
 
     /**
      * @test
      * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
+     *
+     * @param string $mockedTargetBranch
+     * @param boolean $equalToLocal
      */
-    public function writeViolationsToOutputWithTargetForBlacklistCheck($mockedLocalBranch, $mockedTargetBranch)
+    public function writeViolationsToOutputWithTargetForBlacklistCheck($mockedTargetBranch, $equalToLocal)
     {
         $expectedCommand = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpmd '
             . $this->mockedRootDirectory . ' text ' . $this->mockedPackageDirectory
             . '/src/config/phpmd/ZooRoyalDefault/phpmd.xml --suffixes php --exclude %1$s';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn($equalToLocal);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
@@ -85,7 +85,7 @@ class PHPMessDetectorAdapterTest extends TestCase
             . $this->mockedPackageDirectory . '/src/config/phpmd/ZooRoyalDefault/phpmd.xml --suffixes php';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -122,7 +122,7 @@ class PHPMessDetectorAdapterTest extends TestCase
             . '/src/config/phpmd/ZooRoyalDefault/phpmd.xml --suffixes php --exclude %1$s';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn($equalToLocal);
+            ->with('origin/master')->andReturn($equalToLocal);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
@@ -79,7 +79,6 @@ class PHPMessDetectorAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForWhitelistCheck()
     {
-        $mockedLocalBranch  = 'myLocalBranch';
         $mockedTargetBranch = 'myTarget';
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpmd %1$s text '
             . $this->mockedPackageDirectory . '/src/config/phpmd/ZooRoyalDefault/phpmd.xml --suffixes php';

--- a/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
@@ -85,7 +85,6 @@ class PHPParalellLintAdapterTest extends TestCase
      */
     public function writeViolationsToOutputWithTargetForWhitelistCheck()
     {
-        $mockedLocalBranch  = 'myLocalBranch';
         $mockedTargetBranch = 'myTarget';
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s';
 

--- a/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
@@ -90,7 +90,7 @@ class PHPParalellLintAdapterTest extends TestCase
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn(false);
+            ->with('origin/master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -129,7 +129,7 @@ class PHPParalellLintAdapterTest extends TestCase
         $expectedCommand = 'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s ./';
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
-            ->with('master')->andReturn($equalToLocal);
+            ->with('origin/master')->andReturn($equalToLocal);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);

--- a/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPParalellLintAdapterTest.php
@@ -89,8 +89,8 @@ class PHPParalellLintAdapterTest extends TestCase
         $mockedTargetBranch = 'myTarget';
         $expectedCommand    = 'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn(false);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running check on diff to ' . $mockedTargetBranch, OutputInterface::VERBOSITY_NORMAL);
@@ -114,9 +114,9 @@ class PHPParalellLintAdapterTest extends TestCase
     public function writeViolationsToOutputWithTargetForBlacklistCheckDataProvider()
     {
         return [
-            'local master' => ['master', 'myTarget'],
-            'empty target' => ['myBranch', ''],
-            'both'         => ['master', ''],
+            'local master' => ['myTarget', true],
+            'empty target' => ['', true],
+            'both'         => ['', true],
         ];
     }
 
@@ -124,12 +124,12 @@ class PHPParalellLintAdapterTest extends TestCase
      * @test
      * @dataProvider writeViolationsToOutputWithTargetForBlacklistCheckDataProvider
      */
-    public function writeViolationsToOutputWithTargetForBlacklistCheck($mockedLocalBranch, $mockedTargetBranch)
+    public function writeViolationsToOutputWithTargetForBlacklistCheck($mockedTargetBranch, $equalToLocal)
     {
         $expectedCommand = 'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s ./';
 
-        $this->mockedEnvironment->shouldReceive('getLocalBranch')
-            ->withNoArgs()->andReturn('' . $mockedLocalBranch);
+        $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')
+            ->with('master')->andReturn($equalToLocal);
 
         $this->mockedOutputInterface->shouldReceive('writeln')->once()
             ->with('Running full check.', OutputInterface::VERBOSITY_NORMAL);


### PR DESCRIPTION
Branches will now be compared by the commit hash of their HEADs instead of their name to avoid unrecognized aliases.