### PR TITLE
DEV-2096 Timeouts, Comments and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+
+[![Build Status](https://img.shields.io/travis/ZooRoyal/coding-standard/master.svg?longCache=true&style=for-the-badge)](https://travis-ci.org/ZooRoyal/coding-standard) ![Packagist Pre Release](https://img.shields.io/packagist/v/ZooRoyal/coding-standard.svg?longCache=true&style=for-the-badge)
+ [![Packagist](https://img.shields.io/packagist/l/ZooRoyal/coding-standard.svg?longCache=true&style=for-the-badge)]()
+
+
 # ZooRoyal Coding Standard
 
 This repository holds the necessary data to use the ZooRoyal coding standard. It incorporates
@@ -8,7 +13,7 @@ This repository holds the necessary data to use the ZooRoyal coding standard. It
 * [ES-LINT](https://github.com/eslint/eslint) and its configuration
 * [STYLE-LINT](https://github.com/stylelint/stylelint) and its configuration
 
-Furthermore there are the bash scripts in /src/bin which are meant to be used in the .travis build file. They search your source code for files to check by their static code analysis tool. Information about their usage can be found by calling them with -h option.
+Furthermore there is a php script in src/bin which is meant to be used in the .travis build file. It searches your source code for files to check by its static code analysis tools. Information about its usage can be found by calling it with -h option.
 
 # Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,9 +908,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ=="
     },
     "eslint-plugin-react": {
       "version": "7.8.2",

--- a/package.json
+++ b/package.json
@@ -1,24 +1,21 @@
 {
-  "name": "coding-standard",
-  "version": "1.0.0",
-  "description": "ZooRoyal Coding Standard package.json",
-  "private": true,
-  "homepage": "https://github.com/ZooRoyal/coding-standard",
-  "engines": {
-    "node": "^6.9.5"
-  },
-  "dependencies": {
-    "eslint": "^4.15.0",
-    "eslint-config-crockford": "^2.0.0",
-    "eslint-config-m99coder": "^0.1.0",
-    "eslint-config-recommended": "^2.0.0",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-m99coder": "^0.1.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.7.0",
-    "eslint-plugin-standard": "^3.0.1",
-    "stylelint": "^8.4.0",
-    "stylelint-config-recommended": "^2.0.1",
-    "stylelint-config-standard": "^18.0.0"
-  }
+	"name": "coding-standard",
+	"version": "1.0.0",
+	"description": "ZooRoyal Coding Standard package.json",
+	"private": true,
+	"homepage": "https://github.com/ZooRoyal/coding-standard",
+	"dependencies": {
+		"eslint": "^4.15.0",
+		"eslint-config-crockford": "^2.0.0",
+		"eslint-config-m99coder": "^0.1.0",
+		"eslint-config-recommended": "^2.0.0",
+		"eslint-config-standard": "^11.0.0",
+		"eslint-plugin-m99coder": "^0.1.0",
+		"eslint-plugin-node": "^6.0.1",
+		"eslint-plugin-promise": "^3.8.0",
+		"eslint-plugin-standard": "^3.0.1",
+		"stylelint": "^8.4.0",
+		"stylelint-config-recommended": "^2.0.1",
+		"stylelint-config-standard": "^18.0.0"
+	}
 }

--- a/src/config/phpcs/ZooroyalDefault/ruleset.xml
+++ b/src/config/phpcs/ZooroyalDefault/ruleset.xml
@@ -110,6 +110,7 @@
     <rule ref="Squiz.Classes.SelfMemberReference"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
     <rule ref="Squiz.Functions.FunctionDeclaration"/>

--- a/src/main/php/CommandLine/Library/ProcessRunner.php
+++ b/src/main/php/CommandLine/Library/ProcessRunner.php
@@ -36,6 +36,8 @@ class ProcessRunner
     {
         $process = new Process($command);
         $process->run();
+        $process->setTimeout(null);
+        $process->setIdleTimeout(60);
         $process->wait();
 
         return $process;


### PR DESCRIPTION
* Smarter handling of timeouts allows tools to run longer as 60 seconds
* Added DocCommentAlignmentSniff rule to enable PHPCBF to indent
comments
* Added some Batches to Readme
* Removed target engine from package.json