### PR TITLE
DEV-2097 Deactivate Generic.CodeAnalysis.EmptyStatement.DetectedCATCH

### DIFF
--- a/src/config/phpcs/ZooroyalDefault/ruleset.xml
+++ b/src/config/phpcs/ZooroyalDefault/ruleset.xml
@@ -37,6 +37,9 @@
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
+        <severity>0</severity>
+    </rule>
     <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
     <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>


### PR DESCRIPTION
* Deactivate Generic.CodeAnalysis.EmptyStatement.DetectedCATCH by setting severity to 0.