### PR TITLE
ZOO-863: smart option for eslint eqeqeq

### DIFF
--- a/src/config/eslint/.eslintrc.js
+++ b/src/config/eslint/.eslintrc.js
@@ -46,7 +46,7 @@ module.exports = {
             "always"
         ],
         "one-var": "off",
-        "eqeqeq": ["error", "always", {"null": "ignore"}],
+        "eqeqeq": ["error", "smart"],
         "curly": "error",
         "for-direction": "error",
         "no-tabs": "error",


### PR DESCRIPTION
smart
The "smart" option enforces the use of === and !== except for these cases:

Comparing two literal values
Evaluating the value of typeof
Comparing against null

https://eslint.org/docs/rules/eqeqeq#smart