### PR TITLE
CICD-188 Remove stylelint-config-rational-order from stylelint

### DIFF
--- a/config/stylelint/.stylelintrc
+++ b/config/stylelint/.stylelintrc
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "stylelint-config-standard",
-    "stylelint-config-rational-order"
+    "stylelint-config-standard"
   ],
   "rules": {
     "at-rule-no-unknown": null,
@@ -9,7 +8,6 @@
     "no-descending-specificity": null
   },
   "plugins": [
-    "stylelint-order",
-    "stylelint-config-rational-order/plugin"
+    "stylelint-order"
   ]
 }


### PR DESCRIPTION
As decided from the frontend team the rational order should be removed from the style linting