### PR TITLE
Set PHPCS adapter to not escape

### DIFF
--- a/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
@@ -15,7 +15,7 @@ class PHPCodeSnifferAdapter extends AbstractBlackAndWhitelistAdapter implements 
     /** @var string */
     protected $whitelistGlue = ' ';
     /** @var bool */
-    protected $escape = true;
+    protected $escape = false;
 
     /**
      * {@inheritDoc}

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -75,7 +75,7 @@ class PHPCodeSnifferAdapterTest extends TestCase
         self::assertSame('', $this->partialSubject->getBlacklistPrefix());
         self::assertSame(',', $this->partialSubject->getBlacklistGlue());
         self::assertSame(' ', $this->partialSubject->getWhitelistGlue());
-        self::assertTrue($this->partialSubject->isEscape());
+        self::assertFalse($this->partialSubject->isEscape());
 
         MatcherAssert::assertThat(
             $this->partialSubject->getCommands(),


### PR DESCRIPTION
This is necessary because the blacklist was wrongly escaped for bash command resulting in .dontXXX files being ignored