### PR TITLE
cleanup dev dependencies scan files from coding-standard

### DIFF
--- a/config/phpstan/phpstan.neon.dist
+++ b/config/phpstan/phpstan.neon.dist
@@ -10,7 +10,3 @@ parameters:
         maximumNumberOfProcesses: 4
     fileExtensions:
         - php
-    scanFiles:
-        - %rootDir%/../../../vendor/mockery/mockery/library/helpers.php
-        - %rootDir%/../../../vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php
-        - %rootDir%/../../../vendor/sebastianknott/hamcrest-object-accessor/src/functions.php


### PR DESCRIPTION
inserted scan-files are wrong, because are depends on coding-standard dev dependencies 