### PR TITLE
fix empty catch rule

### DIFF
--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -44,7 +44,7 @@
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
+    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCatch">
         <severity>0</severity>
     </rule>
     <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>


### PR DESCRIPTION
DetectedCATCH was renamed to DetectedCatch in [2018/v3.2.3](https://github.com/squizlabs/PHP_CodeSniffer/issues/1909), yet the reference in the Squiz standard is wrong [to this day](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/ruleset.xml#L70).
