### PR TITLE
disable function-calc-no-invalid because of false positives

### DIFF
--- a/config/stylelint/.stylelintrc
+++ b/config/stylelint/.stylelintrc
@@ -5,7 +5,8 @@
   "rules": {
     "at-rule-no-unknown": null,
     "block-no-empty": true,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "function-calc-no-invalid": false
   },
   "plugins": [
     "stylelint-order"


### PR DESCRIPTION
Using Calc functions in css will throw the error: function-calc-no-invalid,
calc functions had to be disabled because of this issue, more info down below:

https://github.com/stylelint/stylelint/issues/4336
