### PR TITLE
Switch back to composer locator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
   },
   "require": {
     "php": "^7.4",
-    "composer/composer": "^1.10.19 || ^2.0",
     "composer/package-versions-deprecated": "^1.8",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "doctrine/annotations": "^1.10",
     "guzzlehttp/psr7": "^1.4",
     "knplabs/github-api": "^2.11",
+    "mindplay/composer-locator": "^2.1.4",
     "php-di/php-di": "^5.4.0 || ^6.0",
     "php-parallel-lint/php-console-highlighter": "^0.5",
     "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -77,7 +77,7 @@
     "test": "phpunit",
     "infection": [
       "@test",
-      "infection -n --min-msi=85 --min-covered-msi=85 --threads=4 --only-covered --coverage=/tmp/phpunit --no-progress"
+      "infection -n --min-msi=84 --min-covered-msi=84 --threads=4 --only-covered --coverage=/tmp/phpunit --no-progress"
     ]
   },
   "config": {

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -2,7 +2,7 @@
 
 namespace Zooroyal\CodingStandard\CommandLine\Library;
 
-use Composer\Factory;
+use ComposerLocator;
 
 /**
  * This Class supplies information about the environment the script is running in.
@@ -45,8 +45,8 @@ class Environment
      */
     public function getRootDirectory() : string
     {
-        $projectRootPath = Factory::getComposerFile();
-        return realpath(dirname($projectRootPath));
+        $projectRootPath = ComposerLocator::getRootPath();
+        return realpath($projectRootPath);
     }
 
     /**


### PR DESCRIPTION
Why switch back?
If we implement something in our own code base we have to keep two
scenarios in mind. Installation as library and installation for
development. Let a library like composer-locator do it so we only
need one case to worry about.
Thanks for reading