### PR TITLE
Make coding-standard robust against execution from other paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ composer update "zooroyal/coding-standard"
 
 # Usage coding-standard
 
+**Please keep in mind, that coding-standard can only run from inside a git 
+repository.**
+
 Run the command to get usage instructions. 
 ```bash
 php vendor/bin/coding-standard

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "guzzlehttp/psr7": "^1.4",
     "knplabs/github-api": "^2.11",
     "mindplay/composer-locator": "^2.1.4",
-    "ocramius/proxy-manager": "^2.0",
+    "ocramius/proxy-manager": " >= 2.2.3 < 3",
     "php-di/php-di": "^5.4.0 || ^6.0",
     "php-parallel-lint/php-console-highlighter": "^0.5",
     "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -44,8 +44,9 @@
     "slevomat/coding-standard": "^6.4.1",
     "squizlabs/php_codesniffer": "^3.4",
     "symfony/console": "^3.4 || ^4.2 || ^5.0",
-    "symfony/finder": "^3.4 || ^4.2 || ^5.0",
-    "symfony/process": "^3.4 || ^4.2 || ^5.0"
+    "symfony/event-dispatcher": "^3.4 || ^4.2 || ^5.2",
+    "symfony/finder": "^3.4 || ^4.2 || ^5.2",
+    "symfony/process": "^3.4 || ^4.2 || ^5.2"
   },
   "require-dev": {
     "ext-json": "*",

--- a/src/bin/coding-standard
+++ b/src/bin/coding-standard
@@ -1,6 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zooroyal\CodingStandard\CommandLine\Factories\ContainerFactory;
+
 $autoloadFiles = [
     __DIR__ . '/../../vendor/autoload.php',
     __DIR__ . '/../../../../autoload.php',
@@ -9,51 +14,13 @@ $autoloadFiles = [
 foreach ($autoloadFiles as $autoloadFile) {
     if (file_exists($autoloadFile)) {
         require_once $autoloadFile;
+        break;
     }
 }
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Zooroyal\CodingStandard\CommandLine\Commands\Checks\ForbiddenChangesCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\AllToolsCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\FindFilesToCheckCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSESLintCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSStyleLintCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCodeSnifferCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPStanCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCopyPasteDetectorCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPMessDetectorCommand;
-use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPParallelLintCommand;
-use Zooroyal\CodingStandard\CommandLine\Factories\ContainerFactory;
-
 $container = ContainerFactory::getContainerInstance();
 
-$parallelLint = $container->get(PHPParallelLintCommand::class);
-$phpCodeSnifferCommand = $container->get(PHPCodeSnifferCommand::class);
-$phpStanCommand = $container->get(PHPStanCommand::class);
-$findFilesToCheckCommand = $container->get(FindFilesToCheckCommand::class);
-$messDetectCommand = $container->get(PHPMessDetectorCommand::class);
-$copyPasteDetectorCommand = $container->get(PHPCopyPasteDetectorCommand::class);
-$esLintCommand = $container->get(JSESLintCommand::class);
-$styleLintCommand = $container->get(JSStyleLintCommand::class);
-$allToolsCommand = $container->get(AllToolsCommand::class);
-$forbiddenChangesCommand = $container->get(ForbiddenChangesCommand::class);
-
-$application = new Application();
-
-// ... register commands
-$application->add($parallelLint);
-$application->add($phpCodeSnifferCommand);
-$application->add($phpStanCommand);
-$application->add($findFilesToCheckCommand);
-$application->add($messDetectCommand);
-$application->add($copyPasteDetectorCommand);
-$application->add($esLintCommand);
-$application->add($styleLintCommand);
-$application->add($allToolsCommand);
-$application->add($forbiddenChangesCommand);
-
-$container->call([$application, 'run'],
+$container->call(
+    [$container->get(Application::class), 'run'],
     [$container->get(InputInterface::class), $container->get(OutputInterface::class)]
 );

--- a/src/main/php/CommandLine/Config/phpdi.php
+++ b/src/main/php/CommandLine/Config/phpdi.php
@@ -1,11 +1,19 @@
 <?php
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Zooroyal\CodingStandard\CommandLine\Factories\ApplicationFactory;
+use Zooroyal\CodingStandard\CommandLine\Factories\EventDispatcherFactory;
+use function DI\factory;
+use function DI\get;
 
 return [
-    InputInterface::class => DI\get(ArgvInput::class),
-    OutputInterface::class => DI\get(ConsoleOutput::class),
+    Application::class => factory(ApplicationFactory::class . '::build'),
+    EventDispatcherInterface::class => factory(EventDispatcherFactory::class . '::build'),
+    InputInterface::class => get(ArgvInput::class),
+    OutputInterface::class => get(ConsoleOutput::class),
 ];

--- a/src/main/php/CommandLine/EventSubscriber/CommandPreconditionChecker.php
+++ b/src/main/php/CommandLine/EventSubscriber/CommandPreconditionChecker.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Zooroyal\CodingStandard\CommandLine\EventSubscriber;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Zooroyal\CodingStandard\CommandLine\Library\ProcessRunner;
+
+/**
+ * Class CommandPreconditionChecker
+ *
+ * This EventSubscriber is meant to be subscribed to the EventDispatcher of the coding-standard application. It
+ * subscribes to the event just before the first command is run and makes sure, that the command is run from inside a
+ * git directory.
+ */
+class CommandPreconditionChecker implements EventSubscriberInterface
+{
+    private ProcessRunner $processRunner;
+    private ?int $exitCode = null;
+    private string $command = 'git rev-parse --git-dir';
+
+    /**
+     * CommandPreconditionChecker constructor.
+     *
+     * @param ProcessRunner $processRunner
+     */
+    public function __construct(ProcessRunner $processRunner)
+    {
+        $this->processRunner = $processRunner;
+    }
+
+    /**
+     * Returns the command event to be subscribed to.
+     *
+     * @return string[]
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [ConsoleEvents::COMMAND => 'checkForGit'];
+    }
+
+    /**
+     * Calls a git command to make sure, that the current working directory is managed by git. If so it does nothing.
+     * If not a exception is thrown.
+     *
+     * @throws RuntimeException
+     */
+    public function checkForGit(): void
+    {
+        if ($this->exitCode === null) {
+            $process = $this->processRunner->runAsProcessReturningProcessObject($this->command);
+
+            $this->exitCode = $process->getExitCode();
+        }
+
+        if ($this->exitCode !== 0) {
+            throw new RuntimeException(
+                'The coding-standard CLI can\'t be used outside of a git context.',
+                1612348705
+            );
+        }
+    }
+}

--- a/src/main/php/CommandLine/Factories/ApplicationFactory.php
+++ b/src/main/php/CommandLine/Factories/ApplicationFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Zooroyal\CodingStandard\CommandLine\Factories;
+
+use DI\Container;
+use Symfony\Component\Console\Application;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Zooroyal\CodingStandard\CommandLine\Commands\Checks\ForbiddenChangesCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\AllToolsCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\FindFilesToCheckCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSESLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSStyleLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCodeSnifferCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCopyPasteDetectorCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPMessDetectorCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPParallelLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPStanCommand;
+
+/**
+ * Class ApplicationFactory
+ * This class builds the Application of symfony/console. It will add all necessary commands. This class is meant to be
+ * used as a PHP-DI factory.
+ * If you want to add your own command just add it's class name to the array $commands.
+ */
+class ApplicationFactory
+{
+    private EventDispatcherInterface $eventDispatcher;
+    private Container $container;
+    /** @var array<string> */
+    private array $commands = [
+        PHPParallelLintCommand::class,
+        PHPCodeSnifferCommand::class,
+        PHPStanCommand::class,
+        FindFilesToCheckCommand::class,
+        PHPMessDetectorCommand::class,
+        PHPCopyPasteDetectorCommand::class,
+        JSESLintCommand::class,
+        JSStyleLintCommand::class,
+        AllToolsCommand::class,
+        ForbiddenChangesCommand::class,
+    ];
+
+    /**
+     * ApplicationFactory constructor.
+     *
+     * @param Container                $container
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(
+        Container $container,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->container = $container;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Builds an instance of Application and sets it up with EventDispatcher and coding-standard Commands.
+     *
+     * @return Application
+     */
+    public function build(): Application
+    {
+        $application = new Application();
+        $application->setDispatcher($this->eventDispatcher);
+
+        foreach ($this->commands as $command) {
+            $application->add($this->container->get($command));
+        }
+
+        return $application;
+    }
+}

--- a/src/main/php/CommandLine/Factories/EventDispatcherFactory.php
+++ b/src/main/php/CommandLine/Factories/EventDispatcherFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zooroyal\CodingStandard\CommandLine\Factories;
+
+use DI\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Zooroyal\CodingStandard\CommandLine\EventSubscriber\CommandPreconditionChecker;
+
+/**
+ * Class EventDispatcherFactory
+ * This class builds the EventDispatcher used in the coding-standard cli. This class is meant to be used as a PHP-DI
+ * factory.
+ */
+class EventDispatcherFactory
+{
+    private Container $container;
+    /** @var array<string> */
+    private array $subscribers = [CommandPreconditionChecker::class];
+
+    /**
+     * EventDispatcherFactory constructor.
+     *
+     * @param Container $container
+     */
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * This method returns the EventDispatcher prehooked with all EventSubscribers used in coding-standard cli.
+     *
+     * @return EventDispatcher
+     */
+    public function build(): EventDispatcher
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        foreach ($this->subscribers as $listener) {
+            $eventDispatcher->addSubscriber($this->container->get($listener));
+        }
+
+        return $eventDispatcher;
+    }
+}

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -45,8 +45,18 @@ class Environment
      */
     public function getRootDirectory() : string
     {
-        $projectRootPath = ComposerLocator::getRootPath();
-        return realpath($projectRootPath);
+        $projectRootPath = $this->processRunner->runAsProcess('git', 'rev-parse', '--show-toplevel');
+        return $projectRootPath;
+    }
+
+    /**
+     * Returns vendor path where coding-standard is installed.
+     *
+     * @return string
+     */
+    public function getVendorPath(): string
+    {
+        return ComposerLocator::getRootPath() . '/vendor';
     }
 
     /**

--- a/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCodeSnifferAdapter.php
@@ -30,16 +30,17 @@ class PHPCodeSnifferAdapter extends AbstractBlackAndWhitelistAdapter implements 
     protected function init()
     {
         $phpCodeSnifferConfig = $this->environment->getPackageDirectory() . '/config/phpcs/ZooRoyal/ruleset.xml';
+        $vendorPath = $this->environment->getVendorPath();
         $rootDirectory = $this->environment->getRootDirectory();
 
-        $sniffWhitelistCommand = 'php ' . $rootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
+        $sniffWhitelistCommand = 'php ' . $vendorPath . '/bin/phpcs -s --extensions=php --standard='
             . $phpCodeSnifferConfig . ' %1$s';
-        $cbfWhitelistCommand = 'php ' . $rootDirectory . '/vendor/bin/phpcbf --extensions=php --standard='
+        $cbfWhitelistCommand = 'php ' . $vendorPath . '/bin/phpcbf --extensions=php --standard='
             . $phpCodeSnifferConfig . ' %1$s';
-        $sniffBlacklistCommand = 'php ' . $rootDirectory
-            . '/vendor/bin/phpcs -s --extensions=php --standard=' . $phpCodeSnifferConfig . ' --ignore=%1$s ' . $rootDirectory;
-        $cbfBlacklistCommand = 'php ' . $rootDirectory
-            . '/vendor/bin/phpcbf --extensions=php --standard=' . $phpCodeSnifferConfig . ' --ignore=%1$s ' . $rootDirectory;
+        $sniffBlacklistCommand = 'php ' . $vendorPath
+            . '/bin/phpcs -s --extensions=php --standard=' . $phpCodeSnifferConfig . ' --ignore=%1$s ' . $rootDirectory;
+        $cbfBlacklistCommand = 'php ' . $vendorPath
+            . '/bin/phpcbf --extensions=php --standard=' . $phpCodeSnifferConfig . ' --ignore=%1$s ' . $rootDirectory;
 
         $this->commands = [
             'PHPCSWL' => $sniffWhitelistCommand,

--- a/src/main/php/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapter.php
@@ -39,9 +39,11 @@ class PHPCopyPasteDetectorAdapter implements ToolAdapterInterface
         $this->genericCommandRunner = $genericCommandRunner;
 
         $this->stopword = '.dontCopyPasteDetectPHP';
+
+        $vendorPath = $environment->getVendorPath();
         $rootDirectory = $environment->getRootDirectory();
 
-        $this->copyPasteDetectCommand = 'php ' . $rootDirectory . '/vendor/bin/phpcpd '
+        $this->copyPasteDetectCommand = 'php ' . $vendorPath . '/bin/phpcpd '
             . '--fuzzy --exclude=ZRBannerSlider.php,Installer.php,ZRPreventShipping.php %1$s '
             . $rootDirectory;
     }

--- a/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPMessDetectorAdapter.php
@@ -26,11 +26,13 @@ class PHPMessDetectorAdapter extends AbstractBlackAndWhitelistAdapter implements
     protected function init()
     {
         $phpMessDetectorConfig = $this->environment->getPackageDirectory() . '/config/phpmd/phpmd.xml';
+
+        $vendorPath = $this->environment->getVendorPath();
         $rootDirectory = $this->environment->getRootDirectory();
 
-        $this->commands['PHPMDWL'] = 'php ' . $rootDirectory . '/vendor/bin/phpmd %1$s' .
+        $this->commands['PHPMDWL'] = 'php ' . $vendorPath . '/bin/phpmd %1$s' .
             ' text ' . $phpMessDetectorConfig . ' --suffixes php';
-        $this->commands['PHPMDBL'] = 'php ' . $rootDirectory . '/vendor/bin/phpmd '
+        $this->commands['PHPMDBL'] = 'php ' . $vendorPath . '/bin/phpmd '
             . $rootDirectory . ' text ' . $phpMessDetectorConfig . ' --suffixes php --exclude %1$s';
     }
 

--- a/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPParallelLintAdapter.php
@@ -16,7 +16,7 @@ class PHPParallelLintAdapter extends AbstractBlackAndWhitelistAdapter implements
     /** @var string[] */
     protected $allowedFileEndings = ['.php'];
     /** @var string */
-    protected $blacklistPrefix = '--exclude ';
+    protected $blacklistPrefix = '';
     /** @var string */
     protected $blacklistGlue = ' ';
     /** @var string */
@@ -27,12 +27,12 @@ class PHPParallelLintAdapter extends AbstractBlackAndWhitelistAdapter implements
      */
     protected function init()
     {
+        $vendorPath = $this->environment->getVendorPath();
         $rootDirectory = $this->environment->getRootDirectory();
 
-        $this->commands['PHPPLWL'] = 'php ' . $rootDirectory
-            . '/vendor/bin/parallel-lint -j 2 %1$s';
-        $this->commands['PHPPLBL'] = 'php ' . $rootDirectory
-            . '/vendor/bin/parallel-lint -j 2 %1$s ./';
+        $this->blacklistPrefix = '--exclude ' . $rootDirectory . '/';
+        $this->commands['PHPPLWL'] = 'php ' . $vendorPath . '/bin/parallel-lint -j 2 %1$s';
+        $this->commands['PHPPLBL'] = 'php ' . $vendorPath . '/bin/parallel-lint -j 2 %1$s ' . $rootDirectory;
     }
 
 

--- a/src/main/php/CommandLine/ToolAdapters/PHPStanAdapter.php
+++ b/src/main/php/CommandLine/ToolAdapters/PHPStanAdapter.php
@@ -50,6 +50,7 @@ class PHPStanAdapter extends AbstractBlackAndWhitelistAdapter implements ToolAda
 
     protected function init()
     {
+        $vendorPath = $this->environment->getVendorPath();
         $rootDirectory = $this->environment->getRootDirectory();
         $phpstanConfig = $this->environment->getPackageDirectory() . '/config/phpstan/phpstan.neon';
 
@@ -61,10 +62,10 @@ class PHPStanAdapter extends AbstractBlackAndWhitelistAdapter implements ToolAda
         $onTheFlyConfig = $this->phpstanConfigGenerator->generateConfig($parameters);
         $this->phpstanConfigGenerator->writeConfig($phpstanConfig, $onTheFlyConfig);
 
-        $this->commands['PHPStanBL'] = 'php ' . $rootDirectory . '/vendor/bin/phpstan analyse --no-progress '
+        $this->commands['PHPStanBL'] = 'php ' . $vendorPath . '/bin/phpstan analyse --no-progress '
             . '--error-format=github ' . $rootDirectory . ' -c ' . $phpstanConfig;
 
-        $this->commands['PHPStanWL'] = 'php ' . $rootDirectory . '/vendor/bin/phpstan analyse --no-progress '
+        $this->commands['PHPStanWL'] = 'php ' . $vendorPath . '/bin/phpstan analyse --no-progress '
             . '--error-format=github ' . '-c ' . $phpstanConfig . ' %1$s';
     }
 

--- a/tests/System/Complete/GlobalSystemTest.php
+++ b/tests/System/Complete/GlobalSystemTest.php
@@ -96,7 +96,7 @@ class GlobalSystemTest extends AsyncTestCase
 
         $result = yield call(Closure::fromCallable([$this, 'runTools']), $environmentDirectory);
 
-        MatcherAssert::assertThat('All Tools are satisfied', $result, H::everyItem(H::is(0)));
+        MatcherAssert::assertThat('All Tools are satisfied.', $result, H::not(H::hasItems(H::greaterThan(0))));
     }
 
     /**

--- a/tests/Tools/SubjectFactory.php
+++ b/tests/Tools/SubjectFactory.php
@@ -3,11 +3,19 @@
 namespace Zooroyal\CodingStandard\Tests\Tools;
 
 use Mockery;
+use Mockery\MockInterface;
 use ReflectionClass;
 
 class SubjectFactory
 {
-    public function buildSubject($className)
+    /**
+     * Builds Subject and it's constructor parameters.
+     *
+     * @param string $className
+     *
+     * @return array<string,object|array<MockInterface>>
+     */
+    public function buildSubject(string $className): array
     {
         $result = ['subject' => null];
         $parameterInstances = [];

--- a/tests/Tools/TestEnvironmentInstallation.php
+++ b/tests/Tools/TestEnvironmentInstallation.php
@@ -94,7 +94,7 @@ class TestEnvironmentInstallation
 
         (new Process(['git', 'init'], $this->installationPath))->mustRun();
         (new Process(['composer', 'install'], $this->installationPath))
-            ->setIdleTimeout(30)->setTimeout(120)->mustRun();
+            ->setIdleTimeout(60)->setTimeout(120)->mustRun();
         $this->filesystem->remove($this->installationPath . '/vendor/zooroyal/coding-standard/node_modules');
         (new Process(['npm', 'install', 'vendor/zooroyal/coding-standard'], $this->installationPath))->mustRun();
         $this->isInstalled = true;

--- a/tests/Tools/TestEnvironmentInstallation.php
+++ b/tests/Tools/TestEnvironmentInstallation.php
@@ -92,6 +92,7 @@ class TestEnvironmentInstallation
         $renderedComposerFile = json_encode($composerTemplate);
         file_put_contents($this->installationPath . DIRECTORY_SEPARATOR . 'composer.json', $renderedComposerFile);
 
+        (new Process(['git', 'init'], $this->installationPath))->mustRun();
         (new Process(['composer', 'install'], $this->installationPath))
             ->setIdleTimeout(30)->setTimeout(120)->mustRun();
         $this->filesystem->remove($this->installationPath . '/vendor/zooroyal/coding-standard/node_modules');

--- a/tests/Unit/CommandLine/EventSubscriber/CommandPreconditionCheckerTest.php
+++ b/tests/Unit/CommandLine/EventSubscriber/CommandPreconditionCheckerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\EventSubscriber;
+
+use Hamcrest\MatcherAssert;
+use Hamcrest\Matchers as H;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+use Zooroyal\CodingStandard\CommandLine\EventSubscriber\CommandPreconditionChecker;
+use Zooroyal\CodingStandard\CommandLine\Library\ProcessRunner;
+use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
+
+class CommandPreconditionCheckerTest extends TestCase
+{
+    private CommandPreconditionChecker $subject;
+    /** @var array<MockInterface> */
+    private array $subjectParameters;
+
+    public function setUp(): void
+    {
+        $subjectFactory = new SubjectFactory();
+        $buildFragments = $subjectFactory->buildSubject(CommandPreconditionChecker::class);
+        $this->subject = $buildFragments['subject'];
+        $this->subjectParameters = $buildFragments['parameters'];
+    }
+
+    /**
+     * @test
+     */
+    public function getSubscribedEvents()
+    {
+        $events = $this->subject::getSubscribedEvents();
+
+        MatcherAssert::assertThat($events, H::hasKeyValuePair(ConsoleEvents::COMMAND, 'checkForGit'));
+    }
+
+    /**
+     * @test
+     */
+    public function checkForGitRunsCommand()
+    {
+        $mockedProcess = Mockery::mock(Process::class);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcessReturningProcessObject')->once()
+            ->with('git rev-parse --git-dir')->andReturn($mockedProcess);
+
+        $mockedProcess->shouldReceive('getExitCode')->once()->withNoArgs()->andReturn(0);
+
+        $this->subject->checkForGit();
+        $this->subject->checkForGit();
+    }
+
+    /**
+     * @test
+     */
+    public function checkForGitThrowsExceptionOnFailedCommand()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1612348705);
+        $this->expectExceptionMessage('The coding-standard CLI can\'t be used outside of a git context.');
+
+        $mockedProcess = Mockery::mock(Process::class);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcessReturningProcessObject')->once()
+            ->with('git rev-parse --git-dir')->andReturn($mockedProcess);
+
+        $mockedProcess->shouldReceive('getExitCode')->once()->withNoArgs()->andReturn(1);
+
+        $this->subject->checkForGit();
+    }
+}

--- a/tests/Unit/CommandLine/Factories/ApplicationFactoryTest.php
+++ b/tests/Unit/CommandLine/Factories/ApplicationFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\Factories;
+
+use DI\Container;
+use Hamcrest\Matchers;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Zooroyal\CodingStandard\CommandLine\Commands\Checks\ForbiddenChangesCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\AllToolsCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\FindFilesToCheckCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSESLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\JSStyleLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCodeSnifferCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPCopyPasteDetectorCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPMessDetectorCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPParallelLintCommand;
+use Zooroyal\CodingStandard\CommandLine\Commands\StaticCodeAnalysis\PHPStanCommand;
+use Zooroyal\CodingStandard\CommandLine\Factories\ApplicationFactory;
+use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
+
+class ApplicationFactoryTest extends TestCase
+{
+    private ApplicationFactory $subject;
+    /** @var array<MockInterface> */
+    private array $subjectParameters;
+    /** @var array<string> */
+    private array $commands = [
+        PHPParallelLintCommand::class,
+        PHPCodeSnifferCommand::class,
+        PHPStanCommand::class,
+        FindFilesToCheckCommand::class,
+        PHPMessDetectorCommand::class,
+        PHPCopyPasteDetectorCommand::class,
+        JSESLintCommand::class,
+        JSStyleLintCommand::class,
+        AllToolsCommand::class,
+        ForbiddenChangesCommand::class,
+    ];
+
+    public function setUp(): void
+    {
+        $subjectFactory = new SubjectFactory();
+        $buildFragments = $subjectFactory->buildSubject(ApplicationFactory::class);
+        $this->subject = $buildFragments['subject'];
+        $this->subjectParameters = $buildFragments['parameters'];
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     */
+    public function build(): void
+    {
+        $mockedApplication = Mockery::mock('overload:' . Application::class);
+        $mockedCommand = Mockery::mock(Command::class);
+
+        $mockedApplication->shouldReceive('setDispatcher')->once()
+            ->with($this->subjectParameters[EventDispatcherInterface::class]);
+
+        $this->subjectParameters[Container::class]->shouldReceive('get')
+            ->with(Matchers::anyOf(...$this->commands))->andReturn($mockedCommand);
+        $mockedApplication->shouldReceive('add')->times(count($this->commands))
+            ->with($mockedCommand);
+
+        $result = $this->subject->build();
+
+        /** @phpstan-ignore-next-line */
+        self::assertSame($result->mockery_getName(), $mockedApplication->mockery_getName());
+    }
+}

--- a/tests/Unit/CommandLine/Factories/EventDispatcherFactoryTest.php
+++ b/tests/Unit/CommandLine/Factories/EventDispatcherFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\Factories;
+
+use DI\Container;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Zooroyal\CodingStandard\CommandLine\EventSubscriber\CommandPreconditionChecker;
+use Zooroyal\CodingStandard\CommandLine\Factories\EventDispatcherFactory;
+use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
+
+class EventDispatcherFactoryTest extends TestCase
+{
+    private EventDispatcherFactory $subject;
+    /** @var array<MockInterface> */
+    private array $subjectParameters;
+
+    public function setUp(): void
+    {
+        $subjectFactory = new SubjectFactory();
+        $buildFragments = $subjectFactory->buildSubject(EventDispatcherFactory::class);
+        $this->subject = $buildFragments['subject'];
+        $this->subjectParameters = $buildFragments['parameters'];
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     */
+    public function build()
+    {
+        $mockedEventDispatcher = Mockery::mock('overload:' . EventDispatcher::class);
+        $mockedCommandPreconditionChecker = Mockery::mock(CommandPreconditionChecker::class);
+
+        $this->subjectParameters[Container::class]->shouldReceive('get')
+            ->with(CommandPreconditionChecker::class)->andReturn($mockedCommandPreconditionChecker);
+        $mockedEventDispatcher->shouldReceive('addSubscriber')->once()
+            ->with($mockedCommandPreconditionChecker);
+
+        $result = $this->subject->build();
+
+        /** @phpstan-ignore-next-line */
+        self::assertSame($result->mockery_getName(), $mockedEventDispatcher->mockery_getName());
+    }
+}

--- a/tests/Unit/CommandLine/Library/EnvironmentTest.php
+++ b/tests/Unit/CommandLine/Library/EnvironmentTest.php
@@ -49,9 +49,24 @@ class EnvironmentTest extends TestCase
      */
     public function getRootDirectory()
     {
+        $expectedPath = 'wurbel scwurbel';
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-parse', '--show-toplevel')->andReturn($expectedPath);
+
         $result = $this->subject->getRootDirectory();
 
+        self::assertSame($expectedPath, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getVendorPath()
+    {
+        $result = $this->subject->getVendorPath();
+
         self::assertTrue(is_dir($result));
+        self::assertStringEndsWith('vendor', $result);
     }
 
     /**

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCodeSnifferAdapterTest.php
@@ -31,6 +31,8 @@ class PHPCodeSnifferAdapterTest extends TestCase
     private $mockedRootDirectory;
     /** @var Mockery\LegacyMockInterface|MockInterface|TerminalCommandFinder */
     private $mockedTerminalCommandFinder;
+    /** @var string */
+    private $mockedVendorDirectory;
 
     protected function setUp(): void
     {
@@ -39,9 +41,12 @@ class PHPCodeSnifferAdapterTest extends TestCase
         $this->mockedOutputInterface = Mockery::mock(OutputInterface::class);
         $this->mockedTerminalCommandFinder = Mockery::mock(TerminalCommandFinder::class);
 
+        $this->mockedVendorDirectory = '/I/Am/The/Vendor';
         $this->mockedPackageDirectory = '/package/directory';
         $this->mockedRootDirectory = '/root/directory';
 
+        $this->mockedEnvironment->shouldReceive('getVendorPath')
+            ->withNoArgs()->andReturn('' . $this->mockedVendorDirectory);
         $this->mockedEnvironment->shouldReceive('getPackageDirectory')
             ->withNoArgs()->andReturn('' . $this->mockedPackageDirectory);
         $this->mockedEnvironment->shouldReceive('getRootDirectory')
@@ -82,22 +87,22 @@ class PHPCodeSnifferAdapterTest extends TestCase
             H::allOf(
                 H::hasKeyValuePair(
                     'PHPCSWL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpcs -s --extensions=php --standard='
                     . $this->mockedPackageDirectory . $config . ' %1$s'
                 ),
                 H::hasKeyValuePair(
                     'PHPCBFWL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcbf --extensions=php --standard='
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpcbf --extensions=php --standard='
                     . $this->mockedPackageDirectory . $config . ' %1$s'
                 ),
                 H::hasKeyValuePair(
                     'PHPCSBL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcs -s --extensions=php --standard='
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpcs -s --extensions=php --standard='
                     . $this->mockedPackageDirectory . $config . ' --ignore=%1$s ' . $this->mockedRootDirectory
                 ),
                 H::hasKeyValuePair(
                     'PHPCBFBL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcbf --extensions=php --standard='
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpcbf --extensions=php --standard='
                     . $this->mockedPackageDirectory . $config . ' --ignore=%1$s ' . $this->mockedRootDirectory
                 )
             )

--- a/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPCopyPasteDetectorAdapterTest.php
@@ -35,6 +35,8 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
     private $expectedPrefix;
     /** @var string */
     private $expectedGlue;
+    /** @var string  */
+    private $mockedVendorDirectory;
 
     protected function setUp(): void
     {
@@ -42,6 +44,7 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
         $this->mockedGenericCommandRunner = Mockery::mock(GenericCommandRunner::class);
         $this->mockedOutputInterface = Mockery::mock(OutputInterface::class);
 
+        $this->mockedVendorDirectory = '/I/Am/The/Vendor';
         $this->mockedPackageDirectory = '/package/directory';
         $this->mockedRootDirectory = '/root/directory';
 
@@ -51,6 +54,8 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
         $this->expectedPrefix = '--exclude ';
         $this->expectedGlue = ' ';
 
+        $this->mockedEnvironment->shouldReceive('getVendorPath')
+            ->withNoArgs()->andReturn('' . $this->mockedVendorDirectory);
         $this->mockedEnvironment->shouldReceive('getPackageDirectory')
             ->withNoArgs()->andReturn('' . $this->mockedPackageDirectory);
         $this->mockedEnvironment->shouldReceive('getRootDirectory')
@@ -83,7 +88,7 @@ class PHPCopyPasteDetectorAdapterTest extends TestCase
     public function writeViolationsToOutputWithTargetForBlacklistCheck()
     {
         $mockedTargetBranch = 'targetBranch';
-        $expectedCommand = 'php ' . $this->mockedRootDirectory . '/vendor/bin/phpcpd --fuzzy ' .
+        $expectedCommand = 'php ' . $this->mockedVendorDirectory . '/bin/phpcpd --fuzzy ' .
             '--exclude=ZRBannerSlider.php,Installer.php,ZRPreventShipping.php %1$s ' . $this->mockedRootDirectory;
 
         $this->mockedEnvironment->shouldReceive('isLocalBranchEqualTo')

--- a/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPMessDetectorAdapterTest.php
@@ -31,6 +31,8 @@ class PHPMessDetectorAdapterTest extends TestCase
     private $mockedRootDirectory;
     /** @var MockInterface|TerminalCommandFinder */
     private $mockedTerminalCommandFinder;
+    /** @var string */
+    private $mockedVendorDirectory;
 
     protected function setUp(): void
     {
@@ -39,9 +41,12 @@ class PHPMessDetectorAdapterTest extends TestCase
         $this->mockedOutputInterface = Mockery::mock(OutputInterface::class);
         $this->mockedTerminalCommandFinder = Mockery::mock(TerminalCommandFinder::class);
 
+        $this->mockedVendorDirectory = '/I/Am/The/Vendor';
         $this->mockedPackageDirectory = '/package/directory';
         $this->mockedRootDirectory = '/root/directory';
 
+        $this->mockedEnvironment->shouldReceive('getVendorPath')
+            ->withNoArgs()->andReturn('' . $this->mockedVendorDirectory);
         $this->mockedEnvironment->shouldReceive('getPackageDirectory')
             ->withNoArgs()->andReturn('' . $this->mockedPackageDirectory);
         $this->mockedEnvironment->shouldReceive('getRootDirectory')
@@ -82,12 +87,13 @@ class PHPMessDetectorAdapterTest extends TestCase
             H::allOf(
                 H::hasKeyValuePair(
                     'PHPMDWL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpmd %1$s text ' . $this->mockedPackageDirectory
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpmd %1$s text ' .
+                    $this->mockedPackageDirectory
                     . $config . ' --suffixes php'
                 ),
                 H::hasKeyValuePair(
                     'PHPMDBL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/phpmd ' . $this->mockedRootDirectory
+                    'php ' . $this->mockedVendorDirectory . '/bin/phpmd ' . $this->mockedRootDirectory
                     . ' text ' . $this->mockedPackageDirectory
                     . $config . ' --suffixes php --exclude %1$s'
                 )

--- a/tests/Unit/CommandLine/ToolAdapters/PHPParallelLintAdapterTest.php
+++ b/tests/Unit/CommandLine/ToolAdapters/PHPParallelLintAdapterTest.php
@@ -31,6 +31,8 @@ class PHPParallelLintAdapterTest extends TestCase
     private $mockedRootDirectory;
     /** @var MockInterface|TerminalCommandFinder */
     private $mockedTerminalCommandFinder;
+    /** @var string */
+    private $mockedVendorDirectory;
 
     protected function setUp(): void
     {
@@ -39,9 +41,12 @@ class PHPParallelLintAdapterTest extends TestCase
         $this->mockedOutputInterface = Mockery::mock(OutputInterface::class);
         $this->mockedTerminalCommandFinder = Mockery::mock(TerminalCommandFinder::class);
 
+        $this->mockedVendorDirectory = '/I/Am/The/Vendor';
         $this->mockedPackageDirectory = '/package/directory';
         $this->mockedRootDirectory = '/root/directory';
 
+        $this->mockedEnvironment->shouldReceive('getVendorPath')
+            ->withNoArgs()->andReturn('' . $this->mockedVendorDirectory);
         $this->mockedEnvironment->shouldReceive('getPackageDirectory')
             ->withNoArgs()->andReturn('' . $this->mockedPackageDirectory);
         $this->mockedEnvironment->shouldReceive('getRootDirectory')
@@ -71,7 +76,7 @@ class PHPParallelLintAdapterTest extends TestCase
     {
         self::assertSame('.dontLintPHP', $this->partialSubject->getBlacklistToken());
         self::assertSame(['.php'], $this->partialSubject->getAllowedFileEndings());
-        self::assertSame('--exclude ', $this->partialSubject->getBlacklistPrefix());
+        self::assertSame('--exclude ' . $this->mockedRootDirectory . '/', $this->partialSubject->getBlacklistPrefix());
         self::assertSame(' ', $this->partialSubject->getBlacklistGlue());
         self::assertSame(' ', $this->partialSubject->getWhitelistGlue());
         self::assertFalse($this->partialSubject->isEscape());
@@ -81,11 +86,11 @@ class PHPParallelLintAdapterTest extends TestCase
             H::allOf(
                 H::hasKeyValuePair(
                     'PHPPLWL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s'
+                    'php ' . $this->mockedVendorDirectory . '/bin/parallel-lint -j 2 %1$s'
                 ),
                 H::hasKeyValuePair(
                     'PHPPLBL',
-                    'php ' . $this->mockedRootDirectory . '/vendor/bin/parallel-lint -j 2 %1$s ./'
+                    'php ' . $this->mockedVendorDirectory . '/bin/parallel-lint -j 2 %1$s ' . $this->mockedRootDirectory
                 )
             )
         );


### PR DESCRIPTION
* Ask the surrounding git repo for it's root
* Distinguish between root directory of code to check and directory
  where coding-standard is installed

# How to check that it works?

* Clone Coding-Standard to filesystem (e.g. /a/cs)
* Composer install
* Switch to another non empty directory outside of coding-standard (e.g. /b)
* Call coding-standard from here (e.g. ../a/src/bin/coding-standard sca:all)
* All PHP-Checks should work as expected