### PR TITLE
Remove check for parameter count

### DIFF
--- a/config/phpstan/phpstan.neon.dist
+++ b/config/phpstan/phpstan.neon.dist
@@ -7,3 +7,6 @@ parameters:
         maximumNumberOfProcesses: 4
     fileExtensions:
         - php
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - '#Function \S+ invoked with [0-9]+ parameters?, [0-9]+ required.#'


### PR DESCRIPTION
* PHPStan is not able to handle global variadic functions.
  This fix can be removed when the following issue might finaly be fixed.
  https://github.com/phpstan/phpstan/issues/37

Should reduce wall of phpstan errors in gh-actions branch.