### PR TITLE
.git in submoduls are files

### DIFF
--- a/src/main/php/CommandLine/Factories/Exclusion/GitPathsExcluder.php
+++ b/src/main/php/CommandLine/Factories/Exclusion/GitPathsExcluder.php
@@ -48,7 +48,7 @@ class GitPathsExcluder implements ExcluderInterface
 
         $rootDirectory = $this->environment->getRootDirectory()->getRealPath();
         $finderResult = $this->processRunner->runAsProcess(
-            'find ' . $rootDirectory . ' -type d -mindepth 2 -name .git' . $excludeParameters
+            'find ' . $rootDirectory . ' -mindepth 2 -name .git' . $excludeParameters
         );
 
         if (empty($finderResult)) {

--- a/tests/Unit/CommandLine/Factories/Exclusion/GitPathsExcluderTest.php
+++ b/tests/Unit/CommandLine/Factories/Exclusion/GitPathsExcluderTest.php
@@ -50,7 +50,7 @@ class GitPathsExcluderTest extends TestCase
             $forgedExcludedDirectories
         );
 
-        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -type d -mindepth 2 -name .git';
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git';
 
         $forgedCommandResult = $this->forgedRootDirectory
             . DIRECTORY_SEPARATOR . $forgedExcludedDirectories[0]
@@ -84,7 +84,7 @@ class GitPathsExcluderTest extends TestCase
             ),
         ];
 
-        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -type d -mindepth 2 -name .git'
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git'
             . ' -not -path "./' . $forgedAlreadyExcluded[0] . '" -not -path "./' . $forgedAlreadyExcluded[1] . '"';
 
         $forgedCommandResult = $this->forgedRootDirectory
@@ -109,7 +109,7 @@ class GitPathsExcluderTest extends TestCase
     {
         $expectedResult = [];
 
-        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -type d -mindepth 2 -name .git';
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git';
 
         $forgedCommandResult = '';
 


### PR DESCRIPTION
```
find /var/www/zooroyal/htdocs -mindepth 2 -type d -name .git
<no results>
```


```
find /var/www/zooroyal/htdocs -mindepth 2 -type f -name .git
/var/www/zooroyal/htdocs/magazin/.git
/var/www/zooroyal/htdocs/custom/plugins/Voucher/.git
/var/www/zooroyal/htdocs/custom/plugins/CommercetoolsConnector/.git
/var/www/zooroyal/htdocs/custom/plugins/ZooRoyalConnector/.git

```


 because .git in submodule are not a directory ⬆️