### PR TITLE
Add rule SlevomatCodingStandard.TypeHints.ReturnTypeHint

### DIFF
--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -158,6 +158,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 
     <!--

--- a/src/main/php/CommandLine/Factories/Excluders/ExclusionListSanitizer.php
+++ b/src/main/php/CommandLine/Factories/Excluders/ExclusionListSanitizer.php
@@ -17,6 +17,8 @@ class ExclusionListSanitizer
      *         Explanation: As the second and the third directories are children of the first it would make
      *         no sense to exclude them "again". As the parent is excluded they are automatically
      *         excluded too.
+     *
+     * @return array<EnhancedFileInfo>
      */
     public function sanitizeExclusionList(array $rawExcludePaths): array
     {

--- a/src/main/php/CommandLine/Factories/Excluders/TokenExcluder.php
+++ b/src/main/php/CommandLine/Factories/Excluders/TokenExcluder.php
@@ -34,6 +34,8 @@ class TokenExcluder implements ExcluderInterface
      *
      * @param array<EnhancedFileInfo> $alreadyExcludedPaths
      * @param array<mixed>  $config
+     *
+     * @return array<EnhancedFileInfo>
      */
     public function getPathsToExclude(array $alreadyExcludedPaths, array $config = []): array
     {

--- a/src/main/php/CommandLine/Library/GitChangeSetFilter.php
+++ b/src/main/php/CommandLine/Library/GitChangeSetFilter.php
@@ -85,6 +85,8 @@ class GitChangeSetFilter
      *
      * @param array<string> $allowedFileEndings
      * @param array<EnhancedFileInfo> $files
+     *
+     * @return array<EnhancedFileInfo>
      */
     private function applyFilters(array $allowedFileEndings, array $files, SplObjectStorage $list): array
     {

--- a/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommand.php
@@ -12,6 +12,8 @@ interface TerminalCommand
     /**
      * Returns a array of command parts. The parts can be used to build a bash command by imploding them with ' ' as
      * glue.
+     *
+     * @return array<string>
      */
     public function toArray(): array;
 }

--- a/src/main/php/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommand.php
@@ -97,8 +97,6 @@ class TerminalCommand extends AbstractTerminalCommand implements
      * Collapse the excludes to a string like '--exclude asdasd --exclude qweqwe'.
      *
      * @param array<string> $finderResultLines
-     *
-     * @return string
      */
     private function collapseExcludes(array $finderResultLines): string
     {

--- a/src/main/php/Github/Commands/PullCommentRefreshCommand.php
+++ b/src/main/php/Github/Commands/PullCommentRefreshCommand.php
@@ -91,6 +91,8 @@ class PullCommentRefreshCommand extends Command
      * Fetches filtered sets of necessary comments
      *
      * @param array<string|bool|int|float|array|null> $arguments
+     *
+     * @return array<array<mixed>>
      */
     private function getCommentSets(array $arguments): array
     {

--- a/src/main/php/Github/Library/CommentFilter.php
+++ b/src/main/php/Github/Library/CommentFilter.php
@@ -8,6 +8,8 @@ class CommentFilter
      * Finds all stale comments which need to be deleted.
      *
      * @param array<mixed> $comments
+     *
+     * @return array<mixed>
      */
     public function filterForStaleComments(array $comments, int $position, string $commitId): array
     {
@@ -26,6 +28,8 @@ class CommentFilter
      * Finds all comments which are written by the current user.
      *
      * @param array<mixed> $comments
+     *
+     * @return array<mixed>
      */
     public function filterForOwnComments(array $comments, string $path, string $login): array
     {

--- a/tests/System/Complete/GlobalSystemTest.php
+++ b/tests/System/Complete/GlobalSystemTest.php
@@ -4,6 +4,7 @@ namespace Zooroyal\CodingStandard\Tests\System\Complete;
 
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Process\Process;
+use Amp\Promise;
 use Closure;
 use Generator;
 use Hamcrest\MatcherAssert;
@@ -32,6 +33,8 @@ class GlobalSystemTest extends AsyncTestCase
      *
      * @large
      * @coversNothing
+     *
+     * @return iterable<Promise<int>>
      */
     public function runCodingStandardToFindErrors(): iterable
     {
@@ -61,6 +64,7 @@ class GlobalSystemTest extends AsyncTestCase
             $copyPromises[] = call([$this->filesystem, 'copy'], $copyFile[0], $copyFile[1]);
         }
 
+        /* @phpstan-ignore-next-line */
         yield $copyPromises;
 
         $result = yield call(Closure::fromCallable([$this, 'runTools']), $environmentDirectory);
@@ -72,9 +76,11 @@ class GlobalSystemTest extends AsyncTestCase
      * @test
      *
      * @large
+     * @coversNothing
+     *
      * @depends runCodingStandardToFindErrors
      *
-     * @coversNothing
+     * @return iterable<Promise>
      */
     public function dontFilesMakeAllGood(): iterable
     {

--- a/tests/System/Eslint/RunEslintWithConfigTest.php
+++ b/tests/System/Eslint/RunEslintWithConfigTest.php
@@ -4,6 +4,7 @@ namespace Zooroyal\CodingStandard\Tests\System\Eslint;
 
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Process\Process;
+use Amp\Promise;
 use Hamcrest\MatcherAssert;
 use Hamcrest\Matchers as H;
 use Zooroyal\CodingStandard\Tests\Tools\TestEnvironmentInstallation;
@@ -25,6 +26,8 @@ class RunEslintWithConfigTest extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return iterable<Promise<int>>
      */
     public function runEslintForJSInCleanInstall(): iterable
     {
@@ -52,6 +55,8 @@ class RunEslintWithConfigTest extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return array<int,Promise>
      */
     public function runEslintForTSInCleanInstall(): iterable
     {
@@ -79,6 +84,8 @@ class RunEslintWithConfigTest extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return iterable<Promise>
      */
     public function runStylelintInCleanInstall(): iterable
     {

--- a/tests/System/Stylelint/RunStylelintWithConfig.php
+++ b/tests/System/Stylelint/RunStylelintWithConfig.php
@@ -4,6 +4,7 @@ namespace Zooroyal\CodingStandard\Tests\System\Stylelint;
 
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Process\Process;
+use Amp\Promise;
 use Hamcrest\MatcherAssert;
 use Hamcrest\Matchers as H;
 use function Amp\ByteStream\buffer;
@@ -14,6 +15,8 @@ class RunStylelintWithConfig extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return array<int,Promise>
      */
     public function findViolationsByEslintInLess(): iterable
     {
@@ -35,6 +38,8 @@ class RunStylelintWithConfig extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return array<int,Promise>
      */
     public function findViolationsByEslintInScss(): iterable
     {
@@ -58,6 +63,8 @@ class RunStylelintWithConfig extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return array<int,Promise>
      */
     public function findViolationsByEslintInSass(): iterable
     {
@@ -81,6 +88,8 @@ class RunStylelintWithConfig extends AsyncTestCase
      * @test
      * @large
      * @coversNothing
+     *
+     * @return array<int,Promise>
      */
     public function findViolationsByEslintInCss(): iterable
     {

--- a/tests/Tools/TerminalCommandTestData.php
+++ b/tests/Tools/TerminalCommandTestData.php
@@ -37,6 +37,7 @@ class TerminalCommandTestData
         $this->processes = $values['processes'] ?? $this->processes;
     }
 
+    /** @return array<EnhancedFileInfo> */
     public function getExcluded(): array
     {
         return $this->excluded;
@@ -47,6 +48,7 @@ class TerminalCommandTestData
         return $this->expectedCommand;
     }
 
+    /** @return array<string> */
     public function getExtensions(): array
     {
         return $this->extensions;
@@ -57,6 +59,7 @@ class TerminalCommandTestData
         return $this->processes;
     }
 
+    /** @return array<EnhancedFileInfo>|null */
     public function getTargets(): ?array
     {
         return $this->targets;

--- a/tests/Unit/CommandLine/Factories/ContainerFactoryTest.php
+++ b/tests/Unit/CommandLine/Factories/ContainerFactoryTest.php
@@ -44,7 +44,7 @@ class ContainerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function getContainerInstanceReturnsSameInstance()
+    public function getContainerInstanceReturnsSameInstance(): void
     {
         $result1 = ContainerFactory::getContainerInstance();
         $result2 = ContainerFactory::getContainerInstance();
@@ -58,7 +58,7 @@ class ContainerFactoryTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState  disabled
      */
-    public function getContainerInstanceConfiguresContainer()
+    public function getContainerInstanceConfiguresContainer(): void
     {
         $expectedContainer = Mockery::mock(Container::class);
         $mockedContainerBuilder = Mockery::mock('overload:'. ContainerBuilder::class);

--- a/tests/Unit/CommandLine/FileFinders/AdaptableFileFinderTest.php
+++ b/tests/Unit/CommandLine/FileFinders/AdaptableFileFinderTest.php
@@ -50,6 +50,8 @@ class AdaptableFileFinderTest extends TestCase
 
     /**
      * Data Provider for findFilesCallsAllCheckableFileFinder.
+     *
+     * @return array<string,array<string,bool|class-string|string|null>>
      */
     public function findFilesCallsAllCheckableFileFinderDataProvider(): array
     {

--- a/tests/Unit/CommandLine/Library/ProcessRunnerTest.php
+++ b/tests/Unit/CommandLine/Library/ProcessRunnerTest.php
@@ -32,7 +32,7 @@ class ProcessRunnerTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState  disabled
      */
-    public function createProcessCreatesNewProcess()
+    public function createProcessCreatesNewProcess(): void
     {
         $overwrittenVersions = Mockery::mock('overload:' . Versions::class);
         $overwrittenProcess = Mockery::mock('overload:' . Process::class);
@@ -92,6 +92,7 @@ class ProcessRunnerTest extends TestCase
         self::assertSame($expectedOutput . PHP_EOL . $expectedError, $result);
     }
 
+    /** @return  array<string,array<int,array<int,string>|string>> */
     public function runAsProcessIsVersionStableDataProvider(): array
     {
         return [
@@ -142,7 +143,7 @@ class ProcessRunnerTest extends TestCase
 
         self::assertInstanceOf(Process::class, $result);
     }
-
+    /** @return array<string,array<array<string>|string>> */
     public function runAsProcessReturningProcessObjectIsVersionStableDataProvider(): array
     {
         return [

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/AllToolsCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/AllToolsCommandTest.php
@@ -124,6 +124,7 @@ class AllToolsCommandTest extends TestCase
         self::assertSame($finalResult, $result);
     }
 
+    /** @return array<string,array<string,array<int|string,bool|int|string>|int>> */
     public function executeCallsAllCommandsDataProvider(): array
     {
         return [

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/Decorators/TargetDecoratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/Decorators/TargetDecoratorTest.php
@@ -111,6 +111,7 @@ class TargetDecoratorTest extends TestCase
         $this->subject->decorate($this->mockedEvent);
     }
 
+    /** @return array<string,array<int,bool|string|null>> */
     public function decorateAddsTargetsToTerminalCommandDataProvider(): array
     {
         return [

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/Decorators/VerbosityDecoratorTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/Decorators/VerbosityDecoratorTest.php
@@ -71,6 +71,7 @@ class VerbosityDecoratorTest extends TestCase
         $this->subject->decorate($this->mockedEvent);
     }
 
+    /** @return array<string,array<int,bool|int>> */
     public function decoradeAddsVerboseFlagIfApplicableDataProvider(): array
     {
         return [

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommandRunnerTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommandRunnerTest.php
@@ -79,6 +79,7 @@ class TerminalCommandRunnerTest extends TestCase
         self::assertSame($exitCode, $result);
     }
 
+    /** @return array<string,array<array<string>|int>> */
     public function runReturnsExitCodeDataProvider(): array
     {
         return [

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/JSESLint/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/JSESLint/TerminalCommandTest.php
@@ -95,6 +95,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/JSStyleLint/TerminalCommandTest.php
@@ -89,6 +89,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCodeSniffer/TerminalCommandTest.php
@@ -92,6 +92,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
@@ -87,6 +87,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPMessDetector/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPMessDetector/TerminalCommandTest.php
@@ -80,6 +80,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPParallelLint/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPParallelLint/TerminalCommandTest.php
@@ -81,6 +81,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPStan/TerminalCommandTest.php
@@ -103,6 +103,8 @@ class TerminalCommandTest extends TestCase
      * This data provider needs to be long because it contains all testing data.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return array<string,array<int,TerminalCommandTestData>>
      */
     public function terminalCommandCompilationDataProvider(): array
     {

--- a/tests/Unit/Github/Library/CommentFilterTest.php
+++ b/tests/Unit/Github/Library/CommentFilterTest.php
@@ -21,6 +21,7 @@ class CommentFilterTest extends TestCase
         parent::tearDown();
     }
 
+    /** @return array<string,array<array<array<string,int|string>>|int|string>> */
     public function filterForStaleCommentsDoesExactlyThatDataProvider(): array
     {
         $position = 1;
@@ -73,6 +74,7 @@ class CommentFilterTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
+    /** @return array<string,array<array<array<string,array<string,string>|string>>|string>> */
     public function filterForOwnCommentsDoesExactlyThatDataProvider(): array
     {
         $path = 'asdasd';


### PR DESCRIPTION
[SlevomatCodingStandard.TypeHints.ReturnTypeHint](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardtypehintsreturntypehint-)

### How to get return types (fast)
![return-types-fast](https://user-images.githubusercontent.com/33318992/136764695-f5f6d809-e78b-4f0f-8d1d-91fdcc4e0e27.gif)

