### PR TITLE
Add test for thecodingmachine/safe to PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "symfony/polyfill-php80": "^1.22",
     "symfony/process": "^3.4.43 || ^4.2 || ^5.2",
     "thecodingmachine/safe": "^1.2",
+    "thecodingmachine/phpstan-safe-rule": "^1.0",
     "webmozart/path-util": "^2.3"
   },
   "require-dev": {
@@ -64,8 +65,7 @@
     "phpunit/php-file-iterator": "^3.0",
     "phpunit/phpunit": "^9.5.2",
     "roave/security-advisories": "dev-master",
-    "sebastianknott/hamcrest-object-accessor": "^2.0",
-    "thecodingmachine/phpstan-safe-rule": "^1.0"
+    "sebastianknott/hamcrest-object-accessor": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
As discussed a week ago the use of thecodingmachine/safe for unsafe build in PHP functions becomes hereby mandatory. 
**Do not forget to add thecodingmachine/safe to your projects composer.json**