### PR TITLE
Add phpcs and PhpStan rules to find useless throws tags

### DIFF
--- a/config/phpcs/ZooRoyal/ruleset.xml
+++ b/config/phpcs/ZooRoyal/ruleset.xml
@@ -113,6 +113,7 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>
             <property name="forbiddenAnnotations" type="array">
@@ -130,6 +131,7 @@
             <property name="allowAboveNonAssignment" type="bool" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>

--- a/config/phpstan/phpstan.neon.dist
+++ b/config/phpstan/phpstan.neon.dist
@@ -10,3 +10,6 @@ parameters:
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - '#Function \S+ invoked with [0-9]+ parameters?, [0-9]+ required.#'
+    exceptions:
+        check:
+            tooWideThrowType: true

--- a/src/main/php/CommandLine/Factories/ContainerFactory.php
+++ b/src/main/php/CommandLine/Factories/ContainerFactory.php
@@ -6,7 +6,6 @@ namespace Zooroyal\CodingStandard\CommandLine\Factories;
 
 use DI\Container;
 use DI\ContainerBuilder;
-use Exception;
 
 class ContainerFactory
 {
@@ -21,8 +20,6 @@ class ContainerFactory
 
     /**
      * Returns the single application container instance to use.
-     *
-     * @throws Exception
      */
     public static function getContainerInstance(): Container
     {
@@ -36,8 +33,6 @@ class ContainerFactory
     /**
      * Returns an unbound Container which is configured like the application container. This is meant to be used for
      * functional tests only.
-     *
-     * @throws Exception
      */
     public static function getUnboundContainerInstance(): Container
     {

--- a/src/main/php/CommandLine/Factories/EnhancedFileInfoFactory.php
+++ b/src/main/php/CommandLine/Factories/EnhancedFileInfoFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Zooroyal\CodingStandard\CommandLine\Factories;
 
 use InvalidArgumentException;
-use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Webmozart\PathUtil\Path;
 use Zooroyal\CodingStandard\CommandLine\Library\ProcessRunner;
 use Zooroyal\CodingStandard\CommandLine\ValueObjects\EnhancedFileInfo;
@@ -31,8 +30,6 @@ class EnhancedFileInfoFactory
      *
      * SmartFileFactory does its best to  return the same instance of EnhancedFileInfo for a file.
      * It uses Inode to distinguish between Files.
-     *
-     * @throws FileNotFoundException
      */
     public function buildFromPath(string $pathName): EnhancedFileInfo
     {

--- a/src/main/php/Github/Commands/PullCommentRefreshCommand.php
+++ b/src/main/php/Github/Commands/PullCommentRefreshCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Zooroyal\CodingStandard\Github\Commands;
 
 use Github\Client;
-use Github\Exception\MissingArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -135,8 +134,6 @@ class PullCommentRefreshCommand extends Command
      * Creates an comment by the given arguments from commandline.
      *
      * @param array<string|bool|int|float|array|null> $arguments
-     *
-     * @throws MissingArgumentException
      */
     private function createComment(array $arguments): void
     {
@@ -161,8 +158,6 @@ class PullCommentRefreshCommand extends Command
      * @param array<mixed> $ownComments
      * @param array<mixed> $staleComments
      * @param array<string|bool|int|float|array|null> $arguments
-     *
-     * @throws MissingArgumentException
      */
     private function updateComment(array $ownComments, array $staleComments, array $arguments): void
     {


### PR DESCRIPTION
* Add [SlevomatCodingStandard.Commenting.EmptyComment](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardcommentingemptycomment-) to get rid of now empty docblocks.
* Add [SlevomatCodingStandard.Commenting.UselessFunctionDocComment](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardcommentinguselessfunctiondoccomment-) to get rid of comments only containing clutter.
* Instruct PHPStan to report @throws without throw in function body
* Fixed Coding-Standard issues with new rules