### PR TITLE
Switch from composer to curl for progressive output testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,13 @@
   "config": {
     "optimize-autoloader": true,
     "sort-packages": true,
-    "process-timeout": 600
+    "process-timeout": 600,
+    "allow-plugins": {
+      "ocramius/package-versions": true,
+      "infection/extension-installer": true,
+      "mindplay/composer-locator": true,
+      "phpstan/extension-installer": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/tests/Functional/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommandRunnerTest.php
+++ b/tests/Functional/CommandLine/StaticCodeAnalysis/Generic/TerminalCommand/TerminalCommandRunnerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\StaticCodeAnalysis\Generic\TerminalCommand;
+namespace Zooroyal\CodingStandard\Tests\Functional\CommandLine\StaticCodeAnalysis\Generic\TerminalCommand;
 
 use Hamcrest\Matchers;
 use Mockery;
@@ -43,7 +43,7 @@ class TerminalCommandRunnerTest extends TestCase
     public function runRelaysOutputOfCommand(): void
     {
         $this->mockedOutput->shouldReceive('write')->once()->with(
-            Matchers::startsWith('Reading ./composer.json'),
+            Matchers::containsString('<!DOCTYPE html>'),
             false,
             Output::OUTPUT_RAW
         );
@@ -51,7 +51,7 @@ class TerminalCommandRunnerTest extends TestCase
         $this->mockedOutput->shouldReceive('write')->atLeast()->once()
             ->with(Mockery::any(), false, Output::OUTPUT_RAW);
 
-        $this->mockedTerminalCommand->shouldReceive('toArray')->andReturn(['composer', 'status', '-vvv']);
+        $this->mockedTerminalCommand->shouldReceive('toArray')->andReturn(['curl', 'https://github.com']);
         $this->subject->run($this->mockedTerminalCommand);
     }
 


### PR DESCRIPTION
Using composer as a test command while executing test lead
to composer writing temp files into the composer directory
while trying to copy it.

Now the tests use curl as test command instead.

## Testing it

If Github Actions is fine everything is tested. If you
want to test it manualy install composer >2 and 
run `composer install && composer test`.