### PR TITLE
Move Environment::isLocalBranchEqualTo to CommitishComparator::isLocalBranchEqualTo

### DIFF
--- a/src/main/php/CommandLine/FileFinders/AdaptableFileFinder.php
+++ b/src/main/php/CommandLine/FileFinders/AdaptableFileFinder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Zooroyal\CodingStandard\CommandLine\FileFinders;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Zooroyal\CodingStandard\CommandLine\Library\Environment;
+use Zooroyal\CodingStandard\CommandLine\Library\CommitishComparator;
 use Zooroyal\CodingStandard\CommandLine\Library\GitInputValidator;
 use Zooroyal\CodingStandard\CommandLine\ValueObjects\GitChangeSet;
 
@@ -17,7 +17,7 @@ class AdaptableFileFinder implements FileFinderInterface
     private GitInputValidator $gitInputValidator;
     private AllCheckableFileFinder $allCheckableFileFinder;
     private DiffCheckableFileFinder $diffCheckableFileFinder;
-    private Environment $environment;
+    private CommitishComparator $commitishComparator;
 
     /**
      * AdaptableFileFinder constructor.
@@ -26,12 +26,12 @@ class AdaptableFileFinder implements FileFinderInterface
         GitInputValidator $gitInputValidator,
         AllCheckableFileFinder $allCheckableFileFinder,
         DiffCheckableFileFinder $diffCheckableFileFinder,
-        Environment $environment
+        CommitishComparator $commitishComparator
     ) {
         $this->gitInputValidator = $gitInputValidator;
         $this->allCheckableFileFinder = $allCheckableFileFinder;
         $this->diffCheckableFileFinder = $diffCheckableFileFinder;
-        $this->environment = $environment;
+        $this->commitishComparator = $commitishComparator;
     }
 
 
@@ -52,7 +52,7 @@ class AdaptableFileFinder implements FileFinderInterface
             throw new InvalidArgumentException('Target ' . $targetBranch . ' is no valid commit-ish.', 1553766210);
         }
 
-        $finder = $targetBranch === null || $this->environment->isLocalBranchEqualTo($targetBranch)
+        $finder = $targetBranch === null || $this->commitishComparator->isLocalBranchEqualTo($targetBranch)
             ? $this->allCheckableFileFinder
             : $this->diffCheckableFileFinder;
 

--- a/src/main/php/CommandLine/Library/CommitishComparator.php
+++ b/src/main/php/CommandLine/Library/CommitishComparator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zooroyal\CodingStandard\CommandLine\Library;
+
+class CommitishComparator
+{
+    private ?string $localHeadHash = null;
+    private GitInputValidator $gitInputValidator;
+    private ProcessRunner $processRunner;
+
+    public function __construct(GitInputValidator $gitInputValidator, ProcessRunner $processRunner)
+    {
+        $this->gitInputValidator = $gitInputValidator;
+        $this->processRunner = $processRunner;
+    }
+
+    /**
+     * Compare if the HEAD of $target Branch equals the HEAD of the local branch.
+     */
+    public function isLocalBranchEqualTo(?string $targetBranch): bool
+    {
+        if (!$this->gitInputValidator->isCommitishValid($targetBranch)) {
+            return false;
+        }
+        if ($this->localHeadHash === null) {
+            $this->localHeadHash = $this->commitishToHash('HEAD');
+        }
+
+        $targetCommitHash = $this->commitishToHash($targetBranch);
+
+        return $targetCommitHash === $this->localHeadHash;
+    }
+
+    /**
+     * Converts a commit-tish to a commit hash.
+     */
+    private function commitishToHash(?string $branchName): string
+    {
+        return $this->processRunner->runAsProcess('git', 'rev-list', '-n 1', $branchName);
+    }
+}

--- a/src/main/php/CommandLine/Library/Environment.php
+++ b/src/main/php/CommandLine/Library/Environment.php
@@ -14,20 +14,16 @@ use function Safe\realpath;
  */
 class Environment
 {
-    private ?string $localHeadHash = null;
     private ProcessRunner $processRunner;
-    private GitInputValidator $gitInputValidator;
     private EnhancedFileInfoFactory $enhancedFileInfoFactory;
     /** @var string */
     private const GIT = 'git';
 
     public function __construct(
         ProcessRunner $processRunner,
-        GitInputValidator $gitInputValidator,
         EnhancedFileInfoFactory $enhancedFileInfoFactory
     ) {
         $this->processRunner = $processRunner;
-        $this->gitInputValidator = $gitInputValidator;
         $this->enhancedFileInfoFactory = $enhancedFileInfoFactory;
     }
 
@@ -61,30 +57,5 @@ class Environment
         $packagePath = dirname(__DIR__, 5);
         $enhancedFileInfo = $this->enhancedFileInfoFactory->buildFromPath($packagePath);
         return $enhancedFileInfo;
-    }
-
-    /**
-     * Compare if the HEAD of $target Branch equals the HEAD of the local branch.
-     */
-    public function isLocalBranchEqualTo(?string $targetBranch): bool
-    {
-        if (!$this->gitInputValidator->isCommitishValid($targetBranch)) {
-            return false;
-        }
-        if ($this->localHeadHash === null) {
-            $this->localHeadHash = $this->commitishToHash('HEAD');
-        }
-
-        $targetCommitHash = $this->commitishToHash($targetBranch);
-
-        return $targetCommitHash === $this->localHeadHash;
-    }
-
-    /**
-     * Converts a commit-tish to a commit hash.
-     */
-    private function commitishToHash(?string $branchName): string
-    {
-        return $this->processRunner->runAsProcess(self::GIT, 'rev-list', '-n 1', $branchName);
     }
 }

--- a/tests/Unit/CommandLine/FileFinders/AdaptableFileFinderTest.php
+++ b/tests/Unit/CommandLine/FileFinders/AdaptableFileFinderTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Zooroyal\CodingStandard\CommandLine\FileFinders\AdaptableFileFinder;
 use Zooroyal\CodingStandard\CommandLine\FileFinders\AllCheckableFileFinder;
 use Zooroyal\CodingStandard\CommandLine\FileFinders\DiffCheckableFileFinder;
-use Zooroyal\CodingStandard\CommandLine\Library\Environment;
+use Zooroyal\CodingStandard\CommandLine\Library\CommitishComparator;
 use Zooroyal\CodingStandard\CommandLine\Library\GitInputValidator;
 use Zooroyal\CodingStandard\CommandLine\ValueObjects\GitChangeSet;
 use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
@@ -98,7 +98,7 @@ class AdaptableFileFinderTest extends TestCase
         $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')
             ->with($targetBranchInput)->andReturn($isCommitishValid);
 
-        $this->subjectParameters[Environment::class]->shouldReceive('isLocalBranchEqualTo')
+        $this->subjectParameters[CommitishComparator::class]->shouldReceive('isLocalBranchEqualTo')
             ->with($targetBranchInput)->andReturn($isLocalBranch);
 
         $this->subjectParameters[$finder]->shouldReceive('findFiles')

--- a/tests/Unit/CommandLine/Library/CommitishComparatorTest.php
+++ b/tests/Unit/CommandLine/Library/CommitishComparatorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\Library;
+
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Zooroyal\CodingStandard\CommandLine\Library\CommitishComparator;
+use Zooroyal\CodingStandard\CommandLine\Library\GitInputValidator;
+use Zooroyal\CodingStandard\CommandLine\Library\ProcessRunner;
+use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
+
+class CommitishComparatorTest extends TestCase
+{
+    private CommitishComparator $subject;
+    /** @var array<MockInterface>|array<mixed> */
+    private array $subjectParameters;
+
+    protected function setUp(): void
+    {
+        $subjectFactory = new SubjectFactory();
+        $buildFragments = $subjectFactory->buildSubject(CommitishComparator::class);
+        $this->subject = $buildFragments['subject'];
+        $this->subjectParameters = $buildFragments['parameters'];
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+
+    /**
+     * @test
+     */
+    public function isLocalBranchEqualToReturnsTrueIfCommitHashesAreEqual(): void
+    {
+        $mockedBranchName = 'my/mocked/branch';
+        $mockedCommitHash = '123qwe0';
+
+        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
+            ->with($mockedBranchName)->andReturn(true);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedCommitHash);
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
+
+        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isLocalBranchEqualToReturnsFalseIfCommitHashesAreUnequal(): void
+    {
+        $mockedBranchName = 'my/mocked/branch';
+        $mockedCommitHash = '123qwe0';
+        $mockedLocalCommitHash = '0ewq321';
+
+        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
+            ->with($mockedBranchName)->andReturn(true);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
+
+        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isLocalBranchEqualToCachesLocalHeadHash(): void
+    {
+        $mockedBranchName = 'my/mocked/branch';
+        $mockedCommitHash = '123qwe0';
+        $mockedLocalCommitHash = '0ewq321';
+
+        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->twice()
+            ->with($mockedBranchName)->andReturn(true);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->twice()
+            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
+
+        $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isLocalBranchEqualToReturnsFalseIfParameterNoBranch(): void
+    {
+        $mockedBranchName = 'my/mocked/branch';
+        $mockedLocalCommitHash = '0ewq321';
+
+        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
+            ->with($mockedBranchName)->andReturn(false);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
+            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
+            ->with('git', 'rev-list', '-n 1', $mockedBranchName);
+
+        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isLocalBranchEqualToWithNull(): void
+    {
+        $mockedBranchName = null;
+
+        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
+            ->with($mockedBranchName)->andReturn(false);
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
+            ->with('git', 'rev-list', '-n 1', 'HEAD');
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
+            ->with('git', 'rev-list', '-n 1', $mockedBranchName);
+
+        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
+        self::assertFalse($result);
+    }
+
+}

--- a/tests/Unit/CommandLine/Library/EnvironmentTest.php
+++ b/tests/Unit/CommandLine/Library/EnvironmentTest.php
@@ -9,7 +9,6 @@ use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Zooroyal\CodingStandard\CommandLine\Factories\EnhancedFileInfoFactory;
 use Zooroyal\CodingStandard\CommandLine\Library\Environment;
-use Zooroyal\CodingStandard\CommandLine\Library\GitInputValidator;
 use Zooroyal\CodingStandard\CommandLine\Library\ProcessRunner;
 use Zooroyal\CodingStandard\CommandLine\ValueObjects\EnhancedFileInfo;
 use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
@@ -85,108 +84,6 @@ class EnvironmentTest extends TestCase
         $result = $this->subject->getPackageDirectory();
 
         self::assertSame($this->mockedEnhancedFileInfo, $result);
-    }
-
-    /**
-     * @test
-     */
-    public function isLocalBranchEqualToReturnsTrueIfCommitHashesAreEqual(): void
-    {
-        $mockedBranchName = 'my/mocked/branch';
-        $mockedCommitHash = '123qwe0';
-
-        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
-            ->with($mockedBranchName)->andReturn(true);
-
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
-            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedCommitHash);
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
-            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
-
-        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        self::assertTrue($result);
-    }
-
-    /**
-     * @test
-     */
-    public function isLocalBranchEqualToReturnsFalseIfCommitHashesAreUnequal(): void
-    {
-        $mockedBranchName = 'my/mocked/branch';
-        $mockedCommitHash = '123qwe0';
-        $mockedLocalCommitHash = '0ewq321';
-
-        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
-            ->with($mockedBranchName)->andReturn(true);
-
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
-            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
-            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
-
-        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        self::assertFalse($result);
-    }
-
-    /**
-     * @test
-     */
-    public function isLocalBranchEqualToCachesLocalHeadHash(): void
-    {
-        $mockedBranchName = 'my/mocked/branch';
-        $mockedCommitHash = '123qwe0';
-        $mockedLocalCommitHash = '0ewq321';
-
-        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->twice()
-            ->with($mockedBranchName)->andReturn(true);
-
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
-            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->twice()
-            ->with('git', 'rev-list', '-n 1', $mockedBranchName)->andReturn($mockedCommitHash);
-
-        $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        self::assertFalse($result);
-    }
-
-    /**
-     * @test
-     */
-    public function isLocalBranchEqualToReturnsFalseIfParameterNoBranch(): void
-    {
-        $mockedBranchName = 'my/mocked/branch';
-        $mockedLocalCommitHash = '0ewq321';
-
-        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
-            ->with($mockedBranchName)->andReturn(false);
-
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
-            ->with('git', 'rev-list', '-n 1', 'HEAD')->andReturn($mockedLocalCommitHash);
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
-            ->with('git', 'rev-list', '-n 1', $mockedBranchName);
-
-        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        self::assertFalse($result);
-    }
-
-    /**
-     * @test
-     */
-    public function isLocalBranchEqualToWithNull(): void
-    {
-        $mockedBranchName = null;
-
-        $this->subjectParameters[GitInputValidator::class]->shouldReceive('isCommitishValid')->once()
-            ->with($mockedBranchName)->andReturn(false);
-
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
-            ->with('git', 'rev-list', '-n 1', 'HEAD');
-        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->never()
-            ->with('git', 'rev-list', '-n 1', $mockedBranchName);
-
-        $result = $this->subject->isLocalBranchEqualTo($mockedBranchName);
-        self::assertFalse($result);
     }
 
 }


### PR DESCRIPTION
This change splits a git operation of the Environement class, as preparatory work to move functionality.

The function Environment::isLocalBranchEqualTo and its subordinates are moved to its own class CommitishComparator

This is related to #159.