### PR TITLE
Old installers are ignored from copy paste detection... again

### DIFF
--- a/src/main/php/CommandLine/StaticCodeAnalysis/Generic/AbstractToolCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/Generic/AbstractToolCommand.php
@@ -49,6 +49,7 @@ abstract class AbstractToolCommand extends Command
         ];
 
         $event = new GenericEvent($this->terminalCommand, $arguments);
+        // @phpstan-ignore-next-line because there is a hack in the symfony/event-dispatcher-contract regarding dispatch
         $this->eventDispatcher->dispatch($event, self::EVENT_DECORATE_TERMINAL_COMMAND);
 
         try {

--- a/src/main/php/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommand.php
+++ b/src/main/php/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommand.php
@@ -62,7 +62,7 @@ class TerminalCommand extends AbstractTerminalCommand implements
     {
         $excludesFilePaths = [];
         $finderResultLines = [];
-        $rootPath = $this->environment->getRootDirectory()->getRelativePathname();
+        $rootPath = $this->environment->getRootDirectory()->getRealPath();
 
         if ($this->excludesFiles !== []) {
             $excludesFilePaths = array_map(
@@ -71,9 +71,9 @@ class TerminalCommand extends AbstractTerminalCommand implements
             );
         }
 
-        $finderResult = $this->processRunner->runAsProcess(
-            'find ' . $rootPath . ' -path \'' . $rootPath . '/custom/plugins/*\' -name Installer.php -maxdepth 4'
-        );
+        $command = ['find', $rootPath, '-path', '*/custom/plugins/*', '-name', 'Installer.php', '-maxdepth', '4'];
+
+        $finderResult = $this->processRunner->runAsProcess(...$command);
 
         if (!empty($finderResult)) {
             $finderResultLines = explode(PHP_EOL, trim($finderResult));

--- a/tests/System/fixtures/complete/Installer.php
+++ b/tests/System/fixtures/complete/Installer.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zooroyal\a;
+
+use SplFileInfo;
+use Webmozart\PathUtil\Path;
+
+class Installer extends SplFileInfo
+{
+    private string $relativePathname;
+
+    public function __construct(string $pathname, string $basePath)
+    {
+        parent::__construct($pathname);
+        $this->relativePathname = Path::makeRelative($pathname, $basePath);
+        $this->relativePathname = empty($this->relativePathname) ? '.' : $this->relativePathname;
+    }
+
+    /**
+     * Returns the relative path name.
+     *
+     * This path contains the file name.
+     */
+    public function getRelativePathname(): string
+    {
+        return $this->relativePathname;
+    }
+
+    /**
+     * Checks if the path name ends with the given suffix.
+     */
+    public function endsWith(string $suffix): bool
+    {
+        return str_ends_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Checks if the path name starts with the given prefix.
+     */
+    public function startsWith(string $suffix): bool
+    {
+        return str_starts_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Returns the relative path name.
+     *
+     * This path contains the file name.
+     */
+    public function getRelativePathname1(): string
+    {
+        return $this->relativePathname;
+    }
+
+    /**
+     * Checks if the path name ends with the given suffix.
+     */
+    public function endsWit1h(string $suffix): bool
+    {
+        return str_ends_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Checks if the path name starts with the given prefix.
+     */
+    public function startsWith1(string $suffix): bool
+    {
+        return str_starts_with($this->getPathname(), $suffix);
+    }
+}

--- a/tests/System/fixtures/complete/Installer2.php
+++ b/tests/System/fixtures/complete/Installer2.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zooroyal\b;
+
+use SplFileInfo;
+use Webmozart\PathUtil\Path;
+
+class Installer extends SplFileInfo
+{
+    private string $relativePathname;
+
+    public function __construct(string $pathname, string $basePath)
+    {
+        parent::__construct($pathname);
+        $this->relativePathname = Path::makeRelative($pathname, $basePath);
+        $this->relativePathname = empty($this->relativePathname) ? '.' : $this->relativePathname;
+    }
+
+    /**
+     * Returns the relative path name.
+     *
+     * This path contains the file name.
+     */
+    public function getRelativePathname(): string
+    {
+        return $this->relativePathname;
+    }
+
+    /**
+     * Checks if the path name ends with the given suffix.
+     */
+    public function endsWith(string $suffix): bool
+    {
+        return str_ends_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Checks if the path name starts with the given prefix.
+     */
+    public function startsWith(string $suffix): bool
+    {
+        return str_starts_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Returns the relative path name.
+     *
+     * This path contains the file name.
+     */
+    public function getRelativePathname1(): string
+    {
+        return $this->relativePathname;
+    }
+
+    /**
+     * Checks if the path name ends with the given suffix.
+     */
+    public function endsWit1h(string $suffix): bool
+    {
+        return str_ends_with($this->getPathname(), $suffix);
+    }
+
+    /**
+     * Checks if the path name starts with the given prefix.
+     */
+    public function startsWith1(string $suffix): bool
+    {
+        return str_starts_with($this->getPathname(), $suffix);
+    }
+}

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
@@ -70,10 +70,19 @@ class TerminalCommandTest extends TestCase
 
         $this->mockedProcessRunner->shouldReceive('runAsProcess')->once()
             ->with(
-                'find ' . self::FORGED_RELATIV_ROOT . ' -path \'' . self::FORGED_RELATIV_ROOT
-                . '/custom/plugins/*\' -name Installer.php -maxdepth 4'
+                'find',
+                self::FORGED_ABSOLUTE_ROOT,
+                '-path',
+                '*/custom/plugins/*',
+                '-name',
+                'Installer.php',
+                '-maxdepth',
+                '4'
             )
-            ->andReturn('blabla/Installer.php' . PHP_EOL . 'blubblub/Installer.php' . PHP_EOL);
+            ->andReturn(
+                self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php' . PHP_EOL
+                . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php' . PHP_EOL
+            );
 
         $this->subject->addAllowedFileExtensions($data->getExtensions());
         $this->subject->addExclusions($data->getExcluded());
@@ -101,8 +110,9 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcpd --fuzzy --suffix qweasd --suffix argh --exclude a/ --exclude b/ '
                             . '--exclude custom/plugins/ZRBannerSlider/ZRBannerSlider.php '
-                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php --exclude blabla/Installer.php '
-                            . '--exclude blubblub/Installer.php .',
+                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
                         'excluded' => [
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/a', self::FORGED_ABSOLUTE_VENDOR),
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/b', self::FORGED_ABSOLUTE_VENDOR),
@@ -117,7 +127,8 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcpd --fuzzy --exclude custom/plugins/ZRBannerSlider/ZRBannerSlider.php '
                             . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php '
-                            . '--exclude blabla/Installer.php --exclude blubblub/Installer.php .',
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
                     ]
                 ),
             ],
@@ -127,8 +138,9 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcpd --fuzzy --exclude a/ --exclude b/ '
                             . '--exclude custom/plugins/ZRBannerSlider/ZRBannerSlider.php '
-                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php --exclude blabla/Installer.php '
-                            . '--exclude blubblub/Installer.php .',
+                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
                         'excluded' => [
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/a', self::FORGED_ABSOLUTE_VENDOR),
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/b', self::FORGED_ABSOLUTE_VENDOR),
@@ -142,8 +154,9 @@ class TerminalCommandTest extends TestCase
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
                             . '/bin/phpcpd --fuzzy --suffix argh --suffix wub '
                             . '--exclude custom/plugins/ZRBannerSlider/ZRBannerSlider.php '
-                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php --exclude blabla/Installer.php '
-                            . '--exclude blubblub/Installer.php .',
+                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
+                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
                         'extensions' => ['argh', 'wub'],
                     ]
                 ),


### PR DESCRIPTION
For some reason™ the detection of old Installers stoped working. 
Now it works again. Installer.php in old Plugins are ignored by
PHPCopyPasteDetector again.