### PR TITLE
Add ignored files from .gitignore to exclusionList of coding-standard

### DIFF
--- a/src/main/php/CommandLine/ApplicationLifeCycle/phpdi.php
+++ b/src/main/php/CommandLine/ApplicationLifeCycle/phpdi.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Zooroyal\CodingStandard\CommandLine\ApplicationLifeCycle\ApplicationFactory;
 use Zooroyal\CodingStandard\CommandLine\ApplicationLifeCycle\EventDispatcherFactory;
+use Zooroyal\CodingStandard\CommandLine\ExclusionList\Excluders\GitIgnoresExcluder;
 use Zooroyal\CodingStandard\CommandLine\ExclusionList\Excluders\GitPathsExcluder;
 use Zooroyal\CodingStandard\CommandLine\ExclusionList\Excluders\StaticExcluder;
 use Zooroyal\CodingStandard\CommandLine\ExclusionList\Excluders\TokenExcluder;
@@ -28,6 +29,7 @@ return [
             $result[] = $container->get(GitPathsExcluder::class);
             $result[] = $container->get(StaticExcluder::class);
             $result[] = $container->get(TokenExcluder::class);
+            $result[] = $container->get(GitIgnoresExcluder::class);
             return $result;
         }
     ),

--- a/src/main/php/CommandLine/Process/ProcessRunner.php
+++ b/src/main/php/CommandLine/Process/ProcessRunner.php
@@ -13,7 +13,11 @@ class ProcessRunner
      */
     public function createProcess(string $command, string ...$arguments): Process
     {
-        $process = new Process([...explode(' ', $command), ...$arguments]);
+        $commandToProcess = $command;
+        if (! empty($arguments)){
+            $commandToProcess .= ' ' . implode(' ', $arguments);
+        }
+        $process = Process::fromShellCommandline($commandToProcess);
         $process->setTimeout(null);
         $process->setIdleTimeout(120);
 

--- a/src/main/php/CommandLine/Process/ProcessRunner.php
+++ b/src/main/php/CommandLine/Process/ProcessRunner.php
@@ -14,9 +14,10 @@ class ProcessRunner
     public function createProcess(string $command, string ...$arguments): Process
     {
         $commandToProcess = $command;
-        if (! empty($arguments)){
+        if (! empty($arguments)) {
             $commandToProcess .= ' ' . implode(' ', $arguments);
         }
+
         $process = Process::fromShellCommandline($commandToProcess);
         $process->setTimeout(null);
         $process->setIdleTimeout(120);

--- a/tests/System/Eslint/RunEslintWithConfigTest.php
+++ b/tests/System/Eslint/RunEslintWithConfigTest.php
@@ -11,7 +11,10 @@ use Hamcrest\MatcherAssert;
 use Hamcrest\Matchers as H;
 use Zooroyal\CodingStandard\Tests\Tools\TestEnvironmentInstallation;
 use function Amp\ByteStream\buffer;
+<<<<<<< Updated upstream
 use function Safe\file_put_contents;
+=======
+>>>>>>> Stashed changes
 
 class RunEslintWithConfigTest extends AsyncTestCase
 {

--- a/tests/System/Eslint/RunEslintWithConfigTest.php
+++ b/tests/System/Eslint/RunEslintWithConfigTest.php
@@ -9,12 +9,9 @@ use Amp\Process\Process;
 use Amp\Promise;
 use Hamcrest\MatcherAssert;
 use Hamcrest\Matchers as H;
+use Symfony\Component\Filesystem\Filesystem;
 use Zooroyal\CodingStandard\Tests\Tools\TestEnvironmentInstallation;
 use function Amp\ByteStream\buffer;
-<<<<<<< Updated upstream
-use function Safe\file_put_contents;
-=======
->>>>>>> Stashed changes
 
 class RunEslintWithConfigTest extends AsyncTestCase
 {
@@ -22,6 +19,13 @@ class RunEslintWithConfigTest extends AsyncTestCase
     private const EXPECTED_JS_PROBLEMS = '185 problems';
     private const ESLINT_COMMAND = 'npx --no-install eslint --config ';
     private const ESLINT_CONFIG_FILE = 'vendor/zooroyal/coding-standard/config/eslint/.eslintrc.js ';
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->filesystem = new Filesystem();
+    }
 
     public static function tearDownAfterClass(): void
     {
@@ -117,20 +121,21 @@ class RunEslintWithConfigTest extends AsyncTestCase
         if ($environment->isInstalled() === false) {
             $environment->addComposerJson(
                 dirname(__DIR__)
-                    . '/fixtures/eslint/composer-template.json'
+                . '/fixtures/eslint/composer-template.json'
             )->installComposerInstance();
         }
         $envInstallationPath = $environment->getInstallationPath();
-        file_put_contents($envInstallationPath . '/tsconfig.json', '{}');
+        $this->filesystem->copy(
+            $envInstallationPath . '/vendor/zooroyal/coding-standard/tests/System/fixtures/eslint/tsconfig.json',
+            $envInstallationPath . '/tsconfig.json'
+        );
         return $envInstallationPath;
     }
 
     private function getEslintCommand(string $fileToCheck, string $testInstancePath): string
     {
         return self::ESLINT_COMMAND
-            . $testInstancePath . DIRECTORY_SEPARATOR
             . self::ESLINT_CONFIG_FILE
-            . $testInstancePath . DIRECTORY_SEPARATOR
             . $fileToCheck;
     }
 }

--- a/tests/System/fixtures/eslint/tsconfig.json
+++ b/tests/System/fixtures/eslint/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "files": [
+    "vendor/zooroyal/coding-standard/tests/System/fixtures/eslint/BadCode.ts"
+  ]
+}

--- a/tests/Unit/CommandLine/ExclusionList/Excluders/GitIgnoresExcluderTest.php
+++ b/tests/Unit/CommandLine/ExclusionList/Excluders/GitIgnoresExcluderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zooroyal\CodingStandard\Tests\Unit\CommandLine\ExclusionList\Excluders;
+
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Zooroyal\CodingStandard\CommandLine\EnhancedFileInfo\EnhancedFileInfo;
+use Zooroyal\CodingStandard\CommandLine\EnhancedFileInfo\EnhancedFileInfoFactory;
+use Zooroyal\CodingStandard\CommandLine\Environment\Environment;
+use Zooroyal\CodingStandard\CommandLine\ExclusionList\Excluders\GitIgnoresExcluder;
+use Zooroyal\CodingStandard\CommandLine\Process\ProcessRunner;
+use Zooroyal\CodingStandard\Tests\Tools\SubjectFactory;
+
+class GitIgnoresExcluderTest extends TestCase
+{
+    private GitIgnoresExcluder $subject;
+    private string $forgedRootDirectory = '/rootDirectory';
+    /** @var array<MockInterface> */
+    private array $subjectParameters;
+
+    protected function setUp(): void
+    {
+        $subjectFactory = new SubjectFactory();
+        $buildFragments = $subjectFactory->buildSubject(GitIgnoresExcluder::class);
+        $this->subject = $buildFragments['subject'];
+        $this->subjectParameters = $buildFragments['parameters'];
+
+        $this->subjectParameters[Environment::class]->shouldReceive('getRootDirectory->getRealPath')
+            ->once()->withNoArgs()->andReturn($this->forgedRootDirectory);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function getPathsToExcludeWithoutParameters(): void
+    {
+        $forgedExcludedDirectories = ['asdasd', 'qweqwe'];
+        $expectedResult = array_map(
+            fn($paths) => new EnhancedFileInfo(
+                $this->forgedRootDirectory . DIRECTORY_SEPARATOR . $paths,
+                $this->forgedRootDirectory
+            ),
+            $forgedExcludedDirectories
+        );
+
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git';
+
+        $forgedCommandResult = $this->forgedRootDirectory
+            . DIRECTORY_SEPARATOR . $forgedExcludedDirectories[0]
+            . DIRECTORY_SEPARATOR . '.git' . PHP_EOL
+            . $this->forgedRootDirectory . DIRECTORY_SEPARATOR . $forgedExcludedDirectories[1]
+            . DIRECTORY_SEPARATOR . '.git' . PHP_EOL;
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')
+            ->once()->with($expectedCommand)->andReturn($forgedCommandResult);
+
+        $this->subjectParameters[EnhancedFileInfoFactory::class]->shouldReceive('buildFromArrayOfPaths')
+            ->once()->with($forgedExcludedDirectories)->andReturn($expectedResult);
+
+        $result = $this->subject->getPathsToExclude([]);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getPathsToExcludeWithAlreadyExcluded(): void
+    {
+        $mockedEnhancedFileInfo1 = Mockery::mock(EnhancedFileInfo::class);
+        $mockedEnhancedFileInfo2 = Mockery::mock(EnhancedFileInfo::class);
+        $mockedEnhancedFileInfoRemaining = Mockery::mock(EnhancedFileInfo::class);
+        $forgedAlreadyExcluded = [$mockedEnhancedFileInfo1, $mockedEnhancedFileInfo2];
+        $forgedExcludedDirectories = [$mockedEnhancedFileInfo1, $mockedEnhancedFileInfoRemaining];
+        $forgedRemainingPaths = [$mockedEnhancedFileInfoRemaining];
+        $expectedResult = [
+            new EnhancedFileInfo(
+                $this->forgedRootDirectory . DIRECTORY_SEPARATOR . $mockedEnhancedFileInfoRemaining,
+                $this->forgedRootDirectory
+            ),
+        ];
+
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git'
+            . ' -not -path "./' . $forgedAlreadyExcluded[0] . '" -not -path "./' . $forgedAlreadyExcluded[1] . '"';
+
+        $forgedCommandResult = $this->forgedRootDirectory
+            . DIRECTORY_SEPARATOR . $forgedExcludedDirectories[1]
+            . DIRECTORY_SEPARATOR . '.git' . PHP_EOL;
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with($expectedCommand)->andReturn($forgedCommandResult);
+
+        $this->subjectParameters[EnhancedFileInfoFactory::class]->shouldReceive('buildFromArrayOfPaths')
+            ->once()->with($forgedRemainingPaths)->andReturn($expectedResult);
+
+        $result = $this->subject->getPathsToExclude($forgedAlreadyExcluded);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getPathsToExcludeFinderFindsNothing(): void
+    {
+        $expectedResult = [];
+
+        $expectedCommand = 'find ' . $this->forgedRootDirectory . ' -mindepth 2 -name .git';
+
+        $forgedCommandResult = '';
+
+        $this->subjectParameters[ProcessRunner::class]->shouldReceive('runAsProcess')->once()
+            ->with($expectedCommand)->andReturn($forgedCommandResult);
+
+        $result = $this->subject->getPathsToExclude([]);
+
+        self::assertSame($expectedResult, $result);
+    }
+}

--- a/tests/Unit/CommandLine/Process/ProcessRunnerTest.php
+++ b/tests/Unit/CommandLine/Process/ProcessRunnerTest.php
@@ -37,7 +37,7 @@ class ProcessRunnerTest extends TestCase
     {
         $overwrittenProcess = Mockery::mock('overload:' . Process::class);
 
-        $overwrittenProcess->shouldReceive('__construct')->once()->with(['ls']);
+        $overwrittenProcess->shouldReceive('fromShellCommandline')->once()->with('ls')->andReturn($overwrittenProcess);
         $overwrittenProcess->shouldReceive('setIdleTimeout')->once()->with(120);
         $overwrittenProcess->shouldReceive('setTimeout')->once()->with(null);
 
@@ -64,13 +64,13 @@ class ProcessRunnerTest extends TestCase
         $commandInput = 'ls';
         $commandArgument1 = '-l';
         $commandArgument2 = '-a';
-        $commandOutput = ['ls', '-l', '-a'];
+        $commandOutput = 'ls -l -a';
 
         $expectedOutput = 'schlurbel';
         $expectedError = 'wurbel';
         $overwrittenProcess = Mockery::mock('overload:' . Process::class);
 
-        $overwrittenProcess->shouldReceive('__construct')->once()->with($commandOutput);
+        $overwrittenProcess->shouldReceive('fromShellCommandline')->once()->with($commandOutput)->andReturn($overwrittenProcess);
         $overwrittenProcess->shouldReceive('mustRun')->once()->withNoArgs();
         $overwrittenProcess->shouldReceive('setIdleTimeout')->once()->with(120);
         $overwrittenProcess->shouldReceive('setTimeout')->once()->with(null);
@@ -104,7 +104,7 @@ class ProcessRunnerTest extends TestCase
     public function runAsProcessReturningProcessObjectIsVersionStable(): void
     {
         $commandInput = 'ls -la';
-        $commandOutput = ['ls', '-la'];
+        $commandOutput = 'ls -la';
 
         $overwrittenProcess = Mockery::mock('overload:' . Process::class);
 
@@ -112,7 +112,7 @@ class ProcessRunnerTest extends TestCase
         $overwrittenProcess->shouldReceive('setIdleTimeout')->once()->with(120);
         $overwrittenProcess->shouldReceive('run')->once();
 
-        $overwrittenProcess->shouldReceive('__construct')->once()->with($commandOutput);
+        $overwrittenProcess->shouldReceive('fromShellCommandline')->once()->with($commandOutput)->andReturn($overwrittenProcess);
 
         $result = $this->subject->runAsProcessReturningProcessObject($commandInput);
 


### PR DESCRIPTION
* Add `GitIgnoresExcluder` to add ignored files from .gitignore to the exclusion list
* Fixed broken eslint system test

## How to test it?
* Install this version of coding-standard in weinfreunde shop.
* Delete all post-*-commands from composer.json
* Execute sca:copy
* Find no false positives