### PR TITLE
Change PHP Copy Paste Detector targeting

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,7 +1,7 @@
 {
     "timeout": 10,
-    "minMsi": 91,
-    "minCoveredMsi": 91,
+    "minMsi": 94,
+    "minCoveredMsi": 94,
     "source": {
         "directories": [
             "src\/main\/php"

--- a/tests/System/Complete/GlobalSystemTest.php
+++ b/tests/System/Complete/GlobalSystemTest.php
@@ -87,7 +87,10 @@ class GlobalSystemTest extends AsyncTestCase
         $this->filesystem->mkdir($badCodeDirectory);
 
         $copyFiles = [
+            [$fixtureDirectory . '/complete/GoodPhp.php', $environmentDirectory . '/custom/plugins/blubblub/Installer.php'],
+            [$fixtureDirectory . '/complete/GoodPhp.php', $environmentDirectory . '/custom/plugins/blabla/Installer.php'],
             [$fixtureDirectory . '/complete/GoodPhp.php', $environmentDirectory . '/GoodPhp.php'],
+            [$fixtureDirectory . '/complete/GoodPhp2.php', $environmentDirectory . '/GoodPhp2.php'],
             [$fixtureDirectory . '/eslint/BadCode.ts', $badCodeDirectory . '/BadCode.ts'],
             [$fixtureDirectory . '/stylelint/BadCode.less', $badCodeDirectory . '/BadCode.less'],
             [$badPhpSnifferFilePath, $badCodeDirectory . '/BadSniffer.php'],
@@ -168,9 +171,13 @@ class GlobalSystemTest extends AsyncTestCase
         return yield new Success($exitCodes);
     }
 
+    /**
+     * Writes unexpected tool output to test log.
+     */
     private function echoStream(string $streamName, Process $process): Generator
     {
-        echo PHP_EOL . PHP_EOL . 'UNEXPECTED TOOL ' . $streamName . ':' . PHP_EOL;
+        echo PHP_EOL . PHP_EOL . 'UNEXPECTED TOOL ' . TestEnvironmentInstallation::getInstance()->getInstallationPath()
+            . ':' . $streamName . ':' . PHP_EOL;
         $buffer = '';
         $streamMethod = 'get' . $streamName;
         while (($chunk = yield $process->$streamMethod()->read()) !== null) {

--- a/tests/System/fixtures/complete/GoodPhp2.php
+++ b/tests/System/fixtures/complete/GoodPhp2.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+echo 'That is very good!';

--- a/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
+++ b/tests/Unit/CommandLine/StaticCodeAnalysis/PHPCopyPasteDetector/TerminalCommandTest.php
@@ -62,13 +62,12 @@ class TerminalCommandTest extends TestCase
         $this->mockedOutput->shouldReceive('writeln')->once()
             ->with(
                 Matchers::startsWith(
-                    '<info>Compiled TerminalCommand to following string</info>'
-                    . PHP_EOL . $data->getExpectedCommand()
+                    '<info>Compiled TerminalCommand to following string</info>' . PHP_EOL . $data->getExpectedCommand()
                 ),
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
 
-        $this->mockedProcessRunner->shouldReceive('runAsProcess')->once()
+        $this->mockedProcessRunner->shouldReceive('runAsProcess')
             ->with(
                 'find',
                 self::FORGED_ABSOLUTE_ROOT,
@@ -86,6 +85,9 @@ class TerminalCommandTest extends TestCase
 
         $this->subject->addAllowedFileExtensions($data->getExtensions());
         $this->subject->addExclusions($data->getExcluded());
+        if ($data->getTargets() !== null) {
+            $this->subject->addTargets($data->getTargets());
+        }
 
         $result = (string) $this->subject;
         $resultingArray = $this->subject->toArray();
@@ -108,16 +110,33 @@ class TerminalCommandTest extends TestCase
                 new TerminalCommandTestData(
                     [
                         'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
-                            . '/bin/phpcpd --fuzzy --suffix qweasd --suffix argh --exclude a/ --exclude b/ '
-                            . '--exclude custom/plugins/ZRBannerSlider/ZRBannerSlider.php '
-                            . '--exclude custom/plugins/ZRPreventShipping/ZRPreventShipping.php '
-                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
-                            . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
+                            . '/bin/phpcpd --fuzzy --suffix qweasd --suffix argh c d',
                         'excluded' => [
                             new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/a', self::FORGED_ABSOLUTE_VENDOR),
-                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/b', self::FORGED_ABSOLUTE_VENDOR),
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_ROOT . '/b', self::FORGED_ABSOLUTE_ROOT),
                         ],
                         'extensions' => ['qweasd', 'argh'],
+                        'targets' => [
+                            new EnhancedFileInfo(
+                                self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php',
+                                self::FORGED_ABSOLUTE_ROOT
+                            ),
+                            new EnhancedFileInfo(
+                                self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php',
+                                self::FORGED_ABSOLUTE_ROOT
+                            ),
+                            new EnhancedFileInfo(
+                                self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/ZRBannerSlider/ZRBannerSlider.php',
+                                self::FORGED_ABSOLUTE_ROOT
+                            ),
+                            new EnhancedFileInfo(
+                                self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/ZRPreventShipping/ZRPreventShipping.php',
+                                self::FORGED_ABSOLUTE_ROOT
+                            ),
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_ROOT . '/b/c', self::FORGED_ABSOLUTE_ROOT),
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_ROOT . '/c', self::FORGED_ABSOLUTE_ROOT),
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_ROOT . '/d', self::FORGED_ABSOLUTE_ROOT),
+                        ],
                     ]
                 ),
             ],
@@ -158,6 +177,18 @@ class TerminalCommandTest extends TestCase
                             . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blabla/Installer.php '
                             . '--exclude ' . self::FORGED_ABSOLUTE_ROOT . '/custom/plugins/blubblub/Installer.php .',
                         'extensions' => ['argh', 'wub'],
+                    ]
+                ),
+            ],
+            'targeted' => [
+                new TerminalCommandTestData(
+                    [
+                        'expectedCommand' => 'php ' . self::FORGED_ABSOLUTE_VENDOR
+                            . '/bin/phpcpd --fuzzy c d',
+                        'targets' => [
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/c', self::FORGED_ABSOLUTE_VENDOR),
+                            new EnhancedFileInfo(self::FORGED_ABSOLUTE_VENDOR . '/d', self::FORGED_ABSOLUTE_VENDOR),
+                        ],
                     ]
                 ),
             ],


### PR DESCRIPTION
* ...from exclude to include to speed up things
 * PHPCPD is not really ignoring excluded files because it still visits
   them while making sure that they should be ignored