### PR TITLE
Update stylelint to version 14

### DIFF
--- a/config/stylelint/.stylelintrc
+++ b/config/stylelint/.stylelintrc
@@ -10,7 +10,6 @@
     "at-rule-no-unknown": null,
     "block-no-empty": true,
     "no-descending-specificity": null,
-    "function-calc-no-invalid": true,
     "indentation": 4,
     "number-leading-zero": "never",
     "max-empty-lines": 2,

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-standard": "4.0.1",
     "jest": "26.6.3",
-    "stylelint": "13.13.1",
+    "stylelint": "^14.14.1",
+    "stylelint-scss": "^4.3.0",
     "stylelint-config-recommended": "3.0.0",
     "stylelint-config-standard": "20.0.0",
-    "stylelint-scss": "3.21.0",
     "typescript": "^4.0.8"
   }
 }


### PR DESCRIPTION
- Update styleint to version 14.14.1
- Remove deprecated rule "function-calc-no-invalid": [https://stylelint.io/migration-guide/to-14/#function-calc-no-invalid-rule](https://stylelint.io/migration-guide/to-14/#function-calc-no-invalid-rule)