### PR TITLE
Fix less-stylecheck

### DIFF
--- a/config/stylelint/.stylelintrc
+++ b/config/stylelint/.stylelintrc
@@ -2,6 +2,7 @@
   "extends": [
     "stylelint-config-standard"
   ],
+  "customSyntax": "postcss-less",
   "ignoreFiles": ["Resources/*/dist/**/**/**"],
   "plugins": [
     "stylelint-scss"
@@ -10,7 +11,6 @@
     "at-rule-no-unknown": null,
     "block-no-empty": true,
     "no-descending-specificity": null,
-    "function-calc-no-invalid": true,
     "indentation": 4,
     "number-leading-zero": "never",
     "max-empty-lines": 2,

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.31.11",
     "jest": "26.6.3",
-    "stylelint": "13.13.1",
+    "stylelint": "14.16.0",
     "stylelint-config-recommended": "3.0.0",
-    "stylelint-config-standard": "20.0.0",
-    "stylelint-scss": "3.21.0",
+    "stylelint-config-standard": "26.0.0",
+    "stylelint-scss": "4.3.0",
     "typescript": "^4.9.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "stylelint-config-standard": "20.0.0",
     "stylelint-scss": "3.21.0",
     "typescript": "^4.9.3"
+  },
+  "devDependencies": {
+    "postcss-less": "^6.0.0"
   }
 }


### PR DESCRIPTION
It solved parsing less-files with messages like "When linting something other than CSS..." . Currently the less-file aren't supported.